### PR TITLE
Fix broken formtools wizard

### DIFF
--- a/mrmap/service/wizards.py
+++ b/mrmap/service/wizards.py
@@ -13,8 +13,8 @@ from service.helper import service_helper
 from service.settings import service_logger
 from structure.permissionEnums import PermissionEnum
 
-FIRST_STEP_ID = _("URL")
-SECOND_STEP_ID = _("Overview")
+FIRST_STEP_ID = "URL"
+SECOND_STEP_ID = "Overview"
 
 NEW_RESOURCE_WIZARD_FORMS = [
     (FIRST_STEP_ID, RegisterNewResourceWizardPage1),


### PR DESCRIPTION
Fix the formtools wizard problem - remove the gettext translation option for the step ids solve https://github.com/mrmap-community/mrmap/issues/82