### PR TITLE
Fix ModuleNotFoundError during gunicorn and celery container startup (set MRMAP_PRODUCTION='False')

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
     build:
       context: ./mrmap
       dockerfile: ../docker/mrmap/Dockerfile
+      args:
+        MRMAP_PRODUCTION: "False"
     entrypoint: /opt/mrmap/.bash_scripts/entrypoint.sh
     command: 
       /bin/bash -c "gunicorn -b 0.0.0.0:8001 -k uvicorn.workers.UvicornWorker --workers=4 --reload --log-level=info --timeout=0 MrMap.asgi:application"
@@ -84,6 +86,8 @@ services:
     build:
       context: ./mrmap
       dockerfile: ../docker/mrmap/Dockerfile
+      args:
+        MRMAP_PRODUCTION: "False"
     command: >
       /bin/bash -c "celery -A MrMap worker -E -l INFO -n default -Q default"
     hostname: "mrmap-celery-default-worker"
@@ -108,6 +112,8 @@ services:
     build:
       context: ./mrmap
       dockerfile: ../docker/mrmap/Dockerfile
+      args:
+        MRMAP_PRODUCTION: "False"
     command: >
       /bin/bash -c "celery -A MrMap worker -E -l INFO -n download -Q download_iso_metadata,download_described_elements,harvest"
     hostname: "mrmap-celery-worker"


### PR DESCRIPTION
Before this fix, the following error occured during gunicorn and celery container startup:

```
celery-download-worker_1  |   File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
celery-download-worker_1  |     return _bootstrap._gcd_import(name[level:], package, level)
celery-download-worker_1  |   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
celery-download-worker_1  |   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
celery-download-worker_1  |   File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
celery-download-worker_1  | ModuleNotFoundError: No module named 'behave_django'
```

This seems to be caused by the following part in `settings.py` and the fact that MRMAP_PRODUCTION is not False for the gunicorn and celery containers:

```python
if os.environ.get("MRMAP_PRODUCTION") == 'False':
    INSTALLED_APPS.append(
        'behave_django',
    )
```

