### PR TITLE
WIP: Add watchdog for Celery worker in Dev environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,15 @@
 # docker compose file for development useage
 version: '3.8'
 services:
+
+  celery-default-worker:
+    command: >
+      /bin/bash -c "watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A MrMap worker -E -l DEBUG -n default -Q default"
+    
+  celery-download-worker:
+    command: >
+      /bin/bash -c "watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A MrMap worker -E -l DEBUG -n download -Q download_iso_metadata,download_described_elements,harvest"
+    
   test:
     build:
       context: ./mrmap

--- a/docker-compose.vscode.yml
+++ b/docker-compose.vscode.yml
@@ -21,7 +21,7 @@ services:
       args:
         MRMAP_PRODUCTION: "False"
     command: >
-      /bin/bash -c "echo 'waiting for debugging client...' && python -u -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m celery -A MrMap worker -E -l DEBUG -n default -Q default"
+      /bin/bash -c "echo 'waiting for debugging client...' && python -u -m debugpy --listen 0.0.0.0:5678 --wait-for-client /usr/local/bin/watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A MrMap worker -E -l DEBUG -n default -Q default"
     environment:
       PYDEVD_LOAD_VALUES_ASYNC: "True"
       PYTHONUNBUFFERED: "1"
@@ -34,7 +34,7 @@ services:
       args:
         MRMAP_PRODUCTION: "False"
     command: >
-      /bin/bash -c "echo 'waiting for debugging client...' && python -u -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m celery -A MrMap worker -E -l DEBUG -n download -Q download_iso_metadata,download_described_elements,harvest"
+      /bin/bash -c "echo 'waiting for debugging client...' && python -u -m debugpy --listen 0.0.0.0:5678 --wait-for-client /usr/local/bin/watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A MrMap worker -E -l DEBUG -n download -Q download_iso_metadata,download_described_elements,harvest"
     environment:
       PYDEVD_LOAD_VALUES_ASYNC: "True"
       PYTHONUNBUFFERED: "1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       args:
         MRMAP_PRODUCTION: "False"
     command: >
-      /bin/bash -c "celery -A MrMap worker -E -l INFO -n default -Q default"
+      /bin/bash -c "watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A MrMap worker -E -l INFO -n default -Q default"
     hostname: "mrmap-celery-default-worker"
     volumes:
       - type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       args:
         MRMAP_PRODUCTION: "False"
     command: >
-      /bin/bash -c "watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A MrMap worker -E -l INFO -n default -Q default"
+      /bin/bash -c "celery -A MrMap worker -E -l INFO -n default -Q default"
     hostname: "mrmap-celery-default-worker"
     volumes:
       - type: bind

--- a/docker/mrmap/Dockerfile
+++ b/docker/mrmap/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=base node_modules/jstree/dist/themes/default/ /tmp/mrmap/static/css/
 COPY --from=base node_modules/bootstrap/dist/js/bootstrap.min.js node_modules/popper.js/dist/umd/popper.min.js node_modules/jquery/dist/jquery.min.js node_modules/jstree/dist/jstree.min.js /tmp/mrmap/static/js/
 
 RUN apt-get -qq update && \
-    apt-get -y install --no-install-recommends wget libssl-dev gdal-bin libpq-dev netcat firefox-esr && \
+    apt-get -y install --no-install-recommends libssl-dev gdal-bin libpq-dev netcat libyaml-dev firefox-esr wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     pip install --no-cache --no-cache-dir /wheels/* && \

--- a/mrmap/requirements.dev.txt
+++ b/mrmap/requirements.dev.txt
@@ -2,4 +2,6 @@ coverage==5.5
 behave-django==1.4.0
 selenium==3.141.0
 behave-webdriver==0.3.0
-watchdog==2.1.5
+watchdog[watchmedo]==2.1.5
+PyYAML==5.4.1
+debugpy==1.4.3  

--- a/mrmap/requirements.dev.txt
+++ b/mrmap/requirements.dev.txt
@@ -2,3 +2,4 @@ coverage==5.5
 behave-django==1.4.0
 selenium==3.141.0
 behave-webdriver==0.3.0
+watchdog==2.1.5


### PR DESCRIPTION
Adds Watchdog to celery worker

- Condition to only use  `Watchmedo` in When not in production is missing

Fixes #188