### PR TITLE
Docker: Use runserver instead of gunicorn in docker-compose.dev

### DIFF
--- a/.run/appserver.run.xml
+++ b/.run/appserver.run.xml
@@ -1,31 +1,23 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Docker-Compose: mrmap debug gunicorn" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="Docker-Compose: mrmap appserver" type="PythonConfigurationType" factoryName="Python">
     <module name="mrmap" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="START_GUNICORN" value="False" />
     </envs>
     <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/mrmap" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
-    <EXTENSION ID="DockerComposeSettingsRunConfigurationExtension" commandLine="up --exit-code-from gunicorn" />
+    <EXTENSION ID="DockerComposeSettingsRunConfigurationExtension" commandLine="up --exit-code-from appserver appserver" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <PathMappingSettings>
-      <option name="pathMappings">
-        <list>
-          <mapping local-root="." remote-root="/opt/mrmap" />
-        </list>
-      </option>
-    </PathMappingSettings>
-    <option name="SCRIPT_NAME" value="gunicorn" />
-    <option name="PARAMETERS" value="-b 0.0.0.0:8001 -k uvicorn.workers.UvicornWorker --workers=4 --reload --log-level=info --timeout=0 MrMap.asgi:application" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/mrmap/manage.py" />
+    <option name="PARAMETERS" value="runserver" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
-    <option name="MODULE_MODE" value="true" />
+    <option name="MODULE_MODE" value="false" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
     <method v="2" />

--- a/.run/celery_default_worker.run.xml
+++ b/.run/celery_default_worker.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Docker-Compose: mrmap debug celery-default-worker" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="Docker-Compose: mrmap celery-default-worker" type="PythonConfigurationType" factoryName="Python">
     <module name="mrmap" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
@@ -11,7 +11,7 @@
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
-    <EXTENSION ID="DockerComposeSettingsRunConfigurationExtension" commandLine="up --exit-code-from gunicorn" />
+    <EXTENSION ID="DockerComposeSettingsRunConfigurationExtension" commandLine="up --exit-code-from celery-default-worker --abort-on-container-exit celery-default-worker" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <PathMappingSettings>
       <option name="pathMappings">

--- a/.run/celery_download_worker.run.xml
+++ b/.run/celery_download_worker.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Docker-Compose: mrmap debug celery-download-worker" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="Docker-Compose: mrmap celery-download-worker" type="PythonConfigurationType" factoryName="Python">
     <module name="mrmap" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
@@ -11,7 +11,7 @@
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
-    <EXTENSION ID="DockerComposeSettingsRunConfigurationExtension" commandLine="up --exit-code-from gunicorn" />
+    <EXTENSION ID="DockerComposeSettingsRunConfigurationExtension" commandLine="up --exit-code-from celery-download-worker --abort-on-container-exit celery-download-worker" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <PathMappingSettings>
       <option name="pathMappings">

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug: gunicorn",
+            "name": "Debug: appserver",
             "type": "python",
             "request": "attach",
             "connect": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
             ]
         },
         {
-            "label": "Docker-Compose: mrmap debug gunicorn",
+            "label": "Docker-Compose: mrmap appserver",
             "type": "shell",
             "command": "docker-compose",
             "args": [
@@ -30,14 +30,14 @@
                 "--remove-orphans",
                 "--build",
                 "--exit-code-from",
-                "gunicorn",
+                "appserver",
                 "--abort-on-container-exit",
-                "gunicorn"
+                "appserver"
             ],
             "problemMatcher": []
         },
         {
-            "label": "Docker-Compose: mrmap debug celery-default-worker",
+            "label": "Docker-Compose: mrmap celery-default-worker",
             "type": "shell",
             "command": "docker-compose",
             "args": [
@@ -57,7 +57,7 @@
             ]
         },
         {
-            "label": "Docker-Compose: mrmap debug celery-download-worker",
+            "label": "Docker-Compose: mrmap celery-download-worker",
             "type": "shell",
             "command": "docker-compose",
             "args": [
@@ -125,7 +125,7 @@
             "args": [
                 "exec",
                 "-it",
-                "mrmap_gunicorn_1",
+                "mrmap_appserver_1",
                 "/opt/mrmap/manage.py",
                 "makemigrations"
             ]
@@ -137,7 +137,7 @@
             "args": [
                 "exec",
                 "-it",
-                "mrmap_gunicorn_1",
+                "mrmap_appserver_1",
                 "/opt/mrmap/manage.py",
                 "migrate"
             ]
@@ -149,7 +149,7 @@
             "args": [
                 "exec",
                 "-it",
-                "mrmap_gunicorn_1",
+                "mrmap_appserver_1",
                 "/opt/mrmap/manage.py",
                 "setup",
                 "--reset-force"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -79,6 +79,8 @@ services:
       env_file:
         - ./.env.mrmap
         - ./.env.mrmap.dev
+      command:
+        /bin/bash -c "python manage.py runserver 0.0.0.0:8001"
 
   celery-default-worker:
       build:
@@ -95,3 +97,9 @@ services:
       env_file:
         - ./.env.mrmap
         - ./.env.mrmap.dev
+
+  nginx:
+    volumes:
+      - type: bind
+        source: ./docker/nginx/mrmap.dev.conf
+        target: /etc/nginx/conf.d/default.conf

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -72,7 +72,7 @@ services:
       - postgis
       - redis
 
-  gunicorn:
+  appserver:
       build:
         args:
           MRMAP_PRODUCTION: "False"

--- a/docker-compose.vscode.yml
+++ b/docker-compose.vscode.yml
@@ -2,20 +2,20 @@
 version: "3.8"
 services:
 
-  gunicorn:
+  appserver:
     command: >
-      /bin/bash -c "echo 'waiting for debugging client...' && python -u -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m gunicorn -b 0.0.0.0:8001 -k uvicorn.workers.UvicornWorker --workers=4 --reload --log-level=debug --timeout=0 MrMap.asgi:application"
+      /bin/bash -c "python -u -m debugpy --listen 0.0.0.0:5678 /opt/mrmap/manage.py runserver 0.0.0.0:8001"
     ports:
       - "0.0.0.0:3001:5678"
   
   celery-default-worker:
     command: >
-      /bin/bash -c "echo 'waiting for debugging client...' && python -u -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m celery -A MrMap worker -E -l DEBUG -n default -Q default"
+      /bin/bash -c "python -u -m debugpy --listen 0.0.0.0:5678 -m celery -A MrMap worker -E -l DEBUG -n default -Q default"
     ports:
       - "0.0.0.0:3002:5678"
 
   celery-download-worker:
     command: >
-      /bin/bash -c "echo 'waiting for debugging client...' && python -u -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m celery -A MrMap worker -E -l DEBUG -n download -Q download_iso_metadata,download_described_elements,harvest"
+      /bin/bash -c "python -u -m debugpy --listen 0.0.0.0:5678 -m celery -A MrMap worker -E -l DEBUG -n download -Q download_iso_metadata,download_described_elements,harvest"
     ports:
       - "0.0.0.0:3003:5678"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   #inspire-validator:
   #  build:
   #    context: ./docker/inspire-validator
-  gunicorn:
+  appserver:
     build:
       context: ./mrmap
       dockerfile: ../docker/mrmap/Dockerfile
@@ -57,7 +57,7 @@ services:
     entrypoint: /opt/mrmap/.bash_scripts/entrypoint.sh
     command: 
       /bin/bash -c "gunicorn -b 0.0.0.0:8001 -k uvicorn.workers.UvicornWorker --workers=4 --reload --log-level=info --timeout=0 MrMap.asgi:application"
-    hostname: "mrmap-gunicorn"
+    hostname: "mrmap-appserver"
     volumes:
       - type: bind
         source: ./mrmap

--- a/docker/nginx/mrmap.conf
+++ b/docker/nginx/mrmap.conf
@@ -1,5 +1,5 @@
-upstream gunicorn {
-    server mrmap-gunicorn:8001;
+upstream appserver {
+    server mrmap-appserver:8001;
 }
 
 server {
@@ -23,7 +23,7 @@ server{
     client_max_body_size 75M;   # adjust to taste
 
     location / {
-        proxy_pass http://gunicorn;
+        proxy_pass http://appserver;
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/docker/nginx/mrmap.dev.conf
+++ b/docker/nginx/mrmap.dev.conf
@@ -1,0 +1,47 @@
+upstream gunicorn {
+    server mrmap-gunicorn:8001;
+}
+
+server {
+    listen      80;
+    server_name localhost;
+    return 301 https://$server_name$request_uri;
+}
+
+server{
+    listen              443 ssl;
+    server_name         localhost;
+    ssl_certificate     /etc/ssl/certs/nginx-selfsigned.crt;
+    ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+    ssl_protocols       TLSv1.2;
+    ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA HIGH !RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+
+    charset     utf-8;
+    # max upload size
+    client_max_body_size 75M;   # adjust to taste
+
+    location / {
+        proxy_pass http://gunicorn;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $server_name;
+    }
+
+    if ($request_method !~ ^(GET|POST)$ ){
+       return 405;
+    }
+
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}

--- a/docker/nginx/mrmap.dev.conf
+++ b/docker/nginx/mrmap.dev.conf
@@ -1,5 +1,5 @@
-upstream gunicorn {
-    server mrmap-gunicorn:8001;
+upstream appserver {
+    server mrmap-appserver:8001;
 }
 
 server {
@@ -23,7 +23,7 @@ server{
     client_max_body_size 75M;   # adjust to taste
 
     location / {
-        proxy_pass http://gunicorn;
+        proxy_pass http://appserver;
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/docs/source/development/pycharm-configuration.rst
+++ b/docs/source/development/pycharm-configuration.rst
@@ -13,7 +13,7 @@ Pycharm configuration
 
 * Open Pycharm and point it to the root directory of mrmap, eg. `/opt/mrmap/`
 * Goto File->Settings->Plugins and search for docker to install it.
-* Goto File->Settings->Build,Execution,Development->Docker
+* Goto File->Settings->Build,Execution,Deployment->Docker
 * Click on the plus sign to add a docker configuation.
 * Use the default settings and click on apply, it should say "Connection successful".
 
@@ -26,8 +26,8 @@ Pycharm configuration
 
 Next we have to mark the mrmap folder as source folder.
 
-* Right click on the mrmap folder in the pycharm directory tree, eg. /opt/mrmap/mrap
-  and select "Mark Directory as -> Source Folder"
+* Right click on the mrmap folder in the pycharm directory tree, eg. /opt/mrmap/mrmap
+  and select "Mark Directory as -> Sources Root"
 
 3. Add remote interpreter
 *************************


### PR DESCRIPTION
This switches from gunicorn to Django's runserver for development with Docker (in Pycharm). Production config and the VS code config remain unaffected for now. @jokiefer Should we change this for the VSCode dev config as well?

With gunicorn, the auto-reloading when changing Python code didn't seem to work very well. Also developing inside static files is more comfortable this way.


Changes:

- Use runserver instead of gunicorn in docker-compose.dev
- Adapted nginx dev config to serve static files via runserver.
- Minor fixes in documentation of Pycharm configuration.
