### PR TITLE
Fixes for Docker/PyCharm dev setup

### DIFF
--- a/.run/appserver.run.xml
+++ b/.run/appserver.run.xml
@@ -13,6 +13,13 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="DockerComposeSettingsRunConfigurationExtension" commandLine="up --exit-code-from appserver appserver" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <PathMappingSettings>
+      <option name="pathMappings">
+        <list>
+          <mapping local-root="." remote-root="/opt/mrmap" />
+        </list>
+      </option>
+    </PathMappingSettings>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/mrmap/manage.py" />
     <option name="PARAMETERS" value="runserver 0.0.0.0:8001" />
     <option name="SHOW_COMMAND_LINE" value="false" />

--- a/.run/appserver.run.xml
+++ b/.run/appserver.run.xml
@@ -14,7 +14,7 @@
     <EXTENSION ID="DockerComposeSettingsRunConfigurationExtension" commandLine="up --exit-code-from appserver appserver" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/mrmap/manage.py" />
-    <option name="PARAMETERS" value="runserver" />
+    <option name="PARAMETERS" value="runserver 0.0.0.0:8001" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.run/mrmap_docker_dev.run.xml
+++ b/.run/mrmap_docker_dev.run.xml
@@ -7,15 +7,20 @@
         <option name="commandLineOptions" value="--build" />
         <option name="secondarySourceFiles">
           <list>
-            <option value="docker-compose.yml" />
+            <option value="docker-compose.dev.yml" />
           </list>
         </option>
-        <option name="sourceFilePath" value="docker-compose.dev.yml" />
+        <option name="services">
+          <list>
+            <option value="appserver" />
+            <option value="celery-default-worker" />
+            <option value="celery-download-worker" />
+          </list>
+        </option>
+        <option name="sourceFilePath" value="docker-compose.yml" />
         <option name="upAlwaysRecreate" value="true" />
-        <option name="upExitCodeFromService" value="" />
         <option name="upForceRecreate" value="true" />
         <option name="upRemoveOrphans" value="true" />
-        <option name="upTimeout" value="" />
       </settings>
     </deployment>
     <method v="2" />


### PR DESCRIPTION
- AppServer run config: Add interface/port (0.0.0.0:8001) parameters (required for nginx to be able to connect)
- Docker Compose DEV config: Fix order of docker-compose.yml files in DEV config, specify services to be started
- AppServer run config: Add path mapping in appserver.run.xml

With these changes, I observed the following:

- AppServer: Auto-reloading works for code changes, debugging works
- Celery: Auto-reloading works for code changes, debugging works

Unfortunately, there are some annoyances left:

- ~Initializing PyCharm takes > 1 min. This seems to be related to the remote interpreter configs.~ Update: This was fixed by creating a local venv and using it as the default Python interpreter for PyCharm. Initializing is reduced to 10s now.
- Stop/Restart buttons do not seem to work for the remote interpreter based run configs, I have to stop/restart services via the Services window

I will check now if using the Debug Server option results in a better experience.