### PR TITLE
Frontend: Fix typescript compile errors

### DIFF
--- a/frontend/src/Components/MapContextForm/MapContext.tsx
+++ b/frontend/src/Components/MapContextForm/MapContext.tsx
@@ -5,9 +5,9 @@ import { useForm } from 'antd/lib/form/Form';
 import React, { FC, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
+import { JsonApiPrimaryData } from '../../Repos/JsonApiRepo';
 import MapContextLayerRepo from '../../Repos/MapContextLayerRepo';
 import MapContextRepo from '../../Repos/MapContextRepo';
-import { hasOwnProperty } from '../../utils';
 import { MPTTListToTreeNodeList, TreeFormField, TreeNodeType } from '../Shared/FormFields/TreeFormField/TreeFormField';
 import { MapContextForm } from './MapContextForm';
 import { MapContextLayerForm } from './MapContextLayerForm';
@@ -73,9 +73,8 @@ export const MapContext: FC<MapContextProps> = () => {
                 setIsSubmittingMapContext(true);
                 try {
                   const response = await mapContextRepo.create(values);
-                  if (response.data?.data &&
-                    hasOwnProperty(response.data.data, 'id')) {
-                    setCreatedMapContextId(response.data.data.id);
+                  if (response.data?.data && (response.data.data as JsonApiPrimaryData).id) {
+                    setCreatedMapContextId((response.data.data as JsonApiPrimaryData).id);
                   }
                   return response;
                 } catch (error) {

--- a/frontend/src/Components/Shared/FormFields/TreeFormField/TreeFormField.tsx
+++ b/frontend/src/Components/Shared/FormFields/TreeFormField/TreeFormField.tsx
@@ -7,8 +7,7 @@ import { Key } from 'antd/lib/table/interface';
 import { DataNode } from 'antd/lib/tree';
 import React, { cloneElement, FC, ReactNode, useEffect, useState } from 'react';
 
-import { JsonApiResponse } from '../../../../Repos/JsonApiRepo';
-import { hasOwnProperty } from '../../../../utils';
+import { JsonApiPrimaryData, JsonApiResponse } from '../../../../Repos/JsonApiRepo';
 
 interface MPTTJsonApiAttributeType {
   name: string;
@@ -376,9 +375,8 @@ export const TreeFormField: FC<TreeProps> = ({
         try {
           const response = await addNodeDispatchAction(values, newNode.parent);
           // update new node key
-          if (response && response.data?.data && hasOwnProperty(response.data.data, 'id')) {
-            // @ts-ignore
-            newNode.key = response.data?.data?.id;
+          if (response && response.data?.data && (response.data.data as JsonApiPrimaryData).id) {
+            newNode.key = (response.data.data as JsonApiPrimaryData).id;
           }
         } catch (error) {
           setIsAddingNode(false);

--- a/frontend/src/Hooks/AuthContextProvider.tsx
+++ b/frontend/src/Hooks/AuthContextProvider.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import LoginRepo from '../Repos/LoginRepo';
 import LogoutRepo from '../Repos/LogoutRepo';
 import { UserRepo } from '../Repos/UserRepo';
-import { hasOwnProperty, useLocalStorage } from '../utils';
+import { useLocalStorage } from '../utils';
 
 export interface AuthContextType {
   user: any;
@@ -31,10 +31,8 @@ export function AuthProvider ({ children }: { children: React.ReactNode }) {
         res.data &&
         res.data.data &&
         // TODO remove this after backend is fixed
-        (res.data.data as any).id &&
-        hasOwnProperty(res.data.data, 'attributes') &&
-        res.data.data.attributes) {
-          setUser(res.data.data.attributes);
+        (res.data.data as any).attributes) {
+          setUser((res.data.data as any).attributes);
         } else {
           // not 200 -> no session for user in backend
           setUserId('');
@@ -56,10 +54,8 @@ export function AuthProvider ({ children }: { children: React.ReactNode }) {
       res.data &&
       res.data.data &&
       // TODO remove this after backend is fixed
-      (res.data.data as any).id &&
-      hasOwnProperty(res.data.data, 'attributes') &&
-      res.data.data.attributes) {
-        setUserId(res.data.data.id);
+      (res.data.data as any).id) {
+        setUserId((res.data.data as any).id);
         return Promise.resolve(true);
       } else {
         return Promise.resolve(false);

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useState } from 'react';
 
-export function hasOwnProperty<X extends Record<string, never>, Y extends PropertyKey>
-(obj: X, prop: Y): obj is X & Record<Y, unknown> {
-  return obj.hasOwnProperty(prop);
-}
-
 function getStorageValue (key: string, defaultValue: any) {
   return localStorage.getItem(key) || defaultValue;
 }


### PR DESCRIPTION
These were caused by obnoxious typing of the 'hasOwnProperty' utility function. Not really needed (after all, for the use cases it doesn't seem to be relevant if properties were not inherited), removed it.