### PR TITLE
Frontend: Improve layout of MapContext editing view

### DIFF
--- a/frontend/src/Components/MapContextForm/MapContext.css
+++ b/frontend/src/Components/MapContextForm/MapContext.css
@@ -1,25 +1,28 @@
 .Map {
-  background: #ffffff;
-  flex: 1 1 auto;
-  display:flex;
-  flex-direction: row;
+  position: relative;
+  height: 100%;
+  width: 100%;
 }
 
 .Map #map {
-  height:100%;
-  width:100%;
+  height: 100%;
+  width: 100%;
 }
 
 .layer-section {
   position: absolute;
-  top: 115px;
-  left: 35px;
-  height: 200px;
+  top: 0.5em;
+  left: 0.5em;
 }
 
 .steps-content {
   width: 100%;
-  height:100%;
-  display:flex;
+  height: 100%;
+  display: flex;
   flex-direction: column;
+}
+
+.ol-zoom {
+  top: unset;
+  bottom: 0.5em;
 }

--- a/frontend/src/Components/MapContextForm/MapContext.tsx
+++ b/frontend/src/Components/MapContextForm/MapContext.tsx
@@ -7,7 +7,6 @@ import OlLayerGroup from 'ol/layer/Group';
 import OlLayerTile from 'ol/layer/Tile';
 import OlMap from 'ol/Map';
 import OlSourceOsm from 'ol/source/OSM';
-import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlView from 'ol/View';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -32,30 +31,6 @@ const layerGroup = new OlLayerGroup({
       source: new OlSourceOsm(),
       // @ts-ignore
       name: 'OSM'
-    }),
-    new OlLayerTile({
-      // @ts-ignore
-      name: 'SRTM30-Contour',
-      minResolution: 0,
-      maxResolution: 10,
-      source: new OlSourceTileWMS({
-        url: 'https://ows.terrestris.de/osm/service',
-        params: {
-          LAYERS: 'SRTM30-Contour'
-        }
-      })
-    }),
-    new OlLayerTile({
-      // @ts-ignore
-      name: 'OSM-Overlay-WMS',
-      minResolution: 0,
-      maxResolution: 200,
-      source: new OlSourceTileWMS({
-        url: 'https://ows.terrestris.de/osm/service',
-        params: {
-          LAYERS: 'OSM-Overlay-WMS'
-        }
-      })
     })
   ]
 });

--- a/frontend/src/Components/Shared/FormFields/TreeFormField/TreeFormField.css
+++ b/frontend/src/Components/Shared/FormFields/TreeFormField/TreeFormField.css
@@ -1,12 +1,13 @@
 .tree-form-field-node {
-  display:flex;
+  display: flex;
   justify-content: space-between;
   align-items: flex-start;
 }
 
 .tree-form-field {
-  border: 1px solid black;
-  height:  100%;
+  height: 100%;
   max-height: 100%;
-  overflow: scroll;
+  padding: 10px 60px 10px 10px;
+  overflow: auto;
+  background: rgb(255, 255, 255);
 }


### PR DESCRIPTION
Changes:

- Move zoom controls to bottom left
- Move layer tree to top left
- Remove layer tree border and and auto-hide scrollbars
- Layer tree overlay size adjusted (leave space on the right side)

![Bildschirmfoto von 2021-12-21 18-16-34](https://user-images.githubusercontent.com/289590/146971633-a46232b9-844f-41ec-b7cb-871f2e4bcfb1.png)
