### PR TITLE
Remove unneeded frontend env variables and enable local "npm start"

### DIFF
--- a/docker/frontend/.mrmap.env
+++ b/docker/frontend/.mrmap.env
@@ -1,3 +1,1 @@
-REACT_APP_REST_API_BASE_URL="https://localhost/"
-REACT_APP_REST_API_SCHEMA_URL="https://localhost/api/schema/"
 NODE_ENV="development"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -106,5 +106,6 @@
       "default",
       "jest-junit"
     ]
-  }
+  },
+  "proxy": "http://localhost:8001/"
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,13 +38,7 @@ function RequireAuth ({ children }:{ children: JSX.Element }) {
 }
 
 export default function App (): JSX.Element {
-  if (process.env.REACT_APP_REST_API_SCHEMA_URL === undefined) {
-    throw new Error('Environment variable REACT_APP_REST_API_SCHEMA_URL is undefined.');
-  }
-  if (process.env.REACT_APP_REST_API_BASE_URL === undefined) {
-    throw new Error('Environment variable REACT_APP_REST_API_BASE_URL is undefined.');
-  }
-  const swaggerUiUrl = process.env.REACT_APP_REST_API_SCHEMA_URL + 'swagger-ui/';
+  const swaggerUiUrl = '/swagger-ui/';
 
   const [collapsed, setCollapsed] = useState(false);
 

--- a/frontend/src/Repos/JsonApiRepo.ts
+++ b/frontend/src/Repos/JsonApiRepo.ts
@@ -38,6 +38,10 @@ export interface QueryParams {
 }
 
 export class JsonApiRepo {
+    private static readonly REACT_APP_REST_API_BASE_URL = '/';
+
+    private static readonly REACT_APP_REST_API_SCHEMA_URL = '/api/schema/';
+
     private static apiInstance: OpenAPIClientAxios;
 
     private static clientInstance: OpenAPIClient;
@@ -60,16 +64,10 @@ export class JsonApiRepo {
 
     static async getApiInstance (): Promise<OpenAPIClientAxios> {
       if (!this.apiInstance) {
-        if (process.env.REACT_APP_REST_API_SCHEMA_URL === undefined) {
-          throw new Error('Environment variable REACT_APP_REST_API_SCHEMA_URL is undefined.');
-        }
-        if (process.env.REACT_APP_REST_API_BASE_URL === undefined) {
-          throw new Error('Environment variable REACT_APP_REST_API_BASE_URL is undefined.');
-        }
         this.apiInstance = new OpenAPIClientAxios({
-          definition: process.env.REACT_APP_REST_API_SCHEMA_URL,
+          definition: JsonApiRepo.REACT_APP_REST_API_SCHEMA_URL,
           axiosConfigDefaults: {
-            baseURL: process.env.REACT_APP_REST_API_BASE_URL
+            baseURL: JsonApiRepo.REACT_APP_REST_API_BASE_URL
           }
         });
         try {


### PR DESCRIPTION
Changes:

- Remove `REACT_APP_REST_API_BASE_URL` and `REACT_APP_REST_API_SCHEMA_URL` variables as we don't need them: The client can safely assume that the api can be fetched from `/api/schema/` and that the base URL of the API is `/`. This is in line with common practices and a very easy approach to solving CORS issues. I cannot imagine that we will need any configurability here for any of the stages (dev/testing/production).
-  `package.json`: Add `proxy` setting to enable local `npm start`. This simply forwards all requests to `http://localhost:8001`, which is the forwarded port of the `backend` container. [More info on the proxy setting](https://create-react-app.dev/docs/proxying-api-requests-in-development/). I tried forwarding to the nginx container first (`https://localhost/`), but ran into some issues with the CSRF check in the backend which seem to be caused by a more strict check when using https instead of http. Directly going to the backend container via http solved this. The `proxy` setting does not hurt when starting the common dev setup inside docker, as only the '/' path should be forwarded from nginx to the `frontend` container. For production, we will not use the npm dev setup anyway, but an optimized production build.