### PR TITLE
Frontend: Add Search / result form to MapContext editor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,19 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Debug: frontend (CRA Tests)",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "${workspaceRoot}/frontend/node_modules/.bin/react-scripts",
+            "args": ["test", "--runInBand", "--no-cache", "--watchAll=false"],
+            "cwd": "${workspaceRoot}/frontend",
+            "protocol": "inspector",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "env": { "CI": "true" },
+            "disableOptimisticBPs": true
+        },
+        {
             "name": "Debug: backend",
             "type": "python",
             "request": "attach",

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,6 +93,9 @@
     "coverageReporters": [
       "default",
       "jest-junit"
+    ],
+    "transformIgnorePatterns" : [
+      "node_modules/(?!(ol|antd|(rc-[a-z-]*)|@ant-design\/css-animation|@ant-design\/pro-[a-z]+|(@ant-design\/icons)(-[a-z]+)*|@babel\/runtime)/)"
     ]
   },
   "proxy": "http://localhost:8001/"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,16 +1,21 @@
-@import '~antd/dist/antd.css';
+@import "~antd/dist/antd.css";
 
 .logo {
   margin: 16px;
 }
 
 .logo img {
-    max-width: 100%;
-    max-height: 100%;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .site-layout-background {
   position: relative;
   width: 100%;
   height: 100%;
+}
+
+.ant-layout-content {
+  /* override element-style from antd layout, so drawer buttons can be placed without gap */
+  margin: 0px 0px !important;
 }

--- a/frontend/src/Components/MapContextForm/MapContext.tsx
+++ b/frontend/src/Components/MapContextForm/MapContext.tsx
@@ -1,5 +1,3 @@
-import './MapContext.css';
-
 import { MapComponent, MapContext as ReactGeoMapContext, useMap } from '@terrestris/react-geo';
 import { Button, Steps } from 'antd';
 import { useForm } from 'antd/lib/form/Form';
@@ -10,14 +8,17 @@ import OlSourceOsm from 'ol/source/OSM';
 import OlView from 'ol/View';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
-
 import { JsonApiPrimaryData } from '../../Repos/JsonApiRepo';
 import MapContextLayerRepo from '../../Repos/MapContextLayerRepo';
 import MapContextRepo from '../../Repos/MapContextRepo';
 import { LayerTree } from '../LayerTree/LayerTree';
+import { SearchDrawer } from '../SearchDrawer/SearchDrawer';
 import { MPTTListToTreeNodeList, TreeNodeType } from '../Shared/FormFields/TreeFormField/TreeFormField';
+import './MapContext.css';
 import { MapContextForm } from './MapContextForm';
 import { MapContextLayerForm } from './MapContextLayerForm';
+
+
 
 const mapContextRepo = new MapContextRepo();
 const mapContextLayerRepo = new MapContextLayerRepo();
@@ -188,6 +189,8 @@ export const MapContext = (): ReactElement => {
               />
             </div>
           </div>
+
+          <SearchDrawer />
 
           <div className='steps-action'>
             <Button

--- a/frontend/src/Components/OgcService/OgcServiceAdd.tsx
+++ b/frontend/src/Components/OgcService/OgcServiceAdd.tsx
@@ -2,10 +2,13 @@ import { InfoCircleOutlined } from '@ant-design/icons';
 import { Button, Card, Checkbox, Form, Input, notification } from 'antd';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import JsonApiRepo from '../../Repos/JsonApiRepo';
 import OrganizationRepo from '../../Repos/OrganizationRepo';
 import { SearchFieldData, SelectAutocompleteFormField } from '../Shared/FormFields/SelectAutocompleteFormField/SelectAutocompleteFormField';
 
-
+interface OgcServiceAddProps {
+  repo: JsonApiRepo;
+}
 const layout = {
   labelCol: { span: 3 },
   wrapperCol: { span: 8 }
@@ -17,7 +20,10 @@ const tailLayout = {
 
 const organizationRepo = new OrganizationRepo();
 
-const OgcServiceAdd = (props: any): ReactElement => {
+const OgcServiceAdd = ({
+  repo
+}: OgcServiceAddProps): ReactElement => {
+
   const [form] = Form.useForm();
 
   const [options, setOptions] = useState<SearchFieldData[]>([]);
@@ -27,7 +33,7 @@ const OgcServiceAdd = (props: any): ReactElement => {
 
   const onFinish = (values: any) => {
     async function postData () {
-      const res = await props.repo.create(values);
+      const res = await repo.create(values);
       if (res.status === 202) {
         notification.info({
           message: 'Service registration job started',

--- a/frontend/src/Components/SearchDrawer/SearchDrawer.css
+++ b/frontend/src/Components/SearchDrawer/SearchDrawer.css
@@ -1,0 +1,22 @@
+.drawer-toggle-btn {
+  position: absolute;
+  top: 20px;
+  z-index: 1001;
+  height: 60px;
+  width: 30px;
+  padding: 0;
+  border-radius: 5px 0 0 5px;
+  border: solid 2px white;
+  border-right: none;
+
+  /* same transition timing as drawer */
+  transition: right 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.drawer-toggle-btn.collapsed {
+  right: 0px;
+}
+
+.drawer-toggle-btn.expanded {
+  right: 1000px;
+}

--- a/frontend/src/Components/SearchDrawer/SearchDrawer.spec.tsx
+++ b/frontend/src/Components/SearchDrawer/SearchDrawer.spec.tsx
@@ -1,0 +1,16 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { SearchDrawer } from './SearchDrawer';
+jest.mock('../../Repos/DatasetMetadataRepo');
+
+describe('SearchDrawer', () => {
+  it('is defined', () => {
+    expect(SearchDrawer).toBeDefined();
+  });
+
+  it('can be rendered', () => {
+    const { container } = render(<SearchDrawer />);
+    expect(container).toBeVisible();
+  });
+});

--- a/frontend/src/Components/SearchDrawer/SearchDrawer.tsx
+++ b/frontend/src/Components/SearchDrawer/SearchDrawer.tsx
@@ -1,0 +1,176 @@
+import { PlusCircleOutlined } from '@ant-design/icons';
+import { Button, Drawer, notification } from "antd";
+import React, { ReactElement, useRef, useState } from 'react';
+import DatasetMetadataRepo from '../../Repos/DatasetMetadataRepo';
+import RepoTable, { RepoTableColumnType } from '../Shared/Table/RepoTable';
+import { buildSearchTransformText } from '../Shared/Table/TableHelper';
+import './SearchDrawer.css';
+
+const repo = new DatasetMetadataRepo();
+
+export const SearchDrawer = (): ReactElement => {
+
+    const [visible, setVisible] = useState<boolean>(true);
+
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    const addDatasetToMap = (dataset: any) => {
+        notification.info({
+          message: `Add dataset '${dataset.title}'`
+        });
+    };
+
+    const columns: RepoTableColumnType[] = [{
+        dataIndex: 'title',
+        title: 'Titel',
+        // disable rendering by return null in renderFormItem, because we cannot set 'hideInSearch: true' for
+        // every data column (otherwise our custom search field would not be rendered by the antd Pro Table)
+        renderFormItem: () => {
+          return null;
+        }
+        // hideInSearch: true
+      }, {
+        dataIndex: 'abstract',
+        title: 'Zusammenfassung',
+        hideInSearch: true
+      }, {
+        dataIndex: 'id',
+        hideInTable: true
+      }, {
+        dataIndex: 'xml_backup_file',
+        hideInTable: true
+      }, {
+        dataIndex: 'access_constraints',
+        hideInTable: true
+      }, {
+        dataIndex: 'fees',
+        hideInTable: true
+      }, {
+        dataIndex: 'use_limitation',
+        hideInTable: true
+      }, {
+        dataIndex: 'file_identifier',
+        hideInTable: true
+      }, {
+        dataIndex: 'license_source_note',
+        hideInTable: true
+      }, {
+        dataIndex: 'date_stamp',
+        hideInTable: true
+      }, {
+        dataIndex: 'origin',
+        hideInTable: true
+      }, {
+        dataIndex: 'origin_url',
+        hideInTable: true
+      }, {
+        dataIndex: 'is_broken',
+        hideInTable: true
+      }, {
+        dataIndex: 'is_customized',
+        hideInTable: true
+      }, {
+        dataIndex: 'insufficient_quality',
+        hideInTable: true
+      }, {
+        dataIndex: 'is_searchable',
+        hideInTable: true
+      }, {
+        dataIndex: 'hits',
+        hideInTable: true
+      }, {
+        dataIndex: 'spatial_res_type',
+        hideInTable: true
+      }, {
+        dataIndex: 'spatial_res_value',
+        hideInTable: true
+      }, {
+        dataIndex: 'format',
+        hideInTable: true
+      }, {
+        dataIndex: 'charset',
+        hideInTable: true
+      }, {
+        dataIndex: 'inspire_top_consistence',
+        hideInTable: true
+      }, {
+        dataIndex: 'preview_image',
+        hideInTable: true
+      }, {
+        dataIndex: 'lineage_statement',
+        hideInTable: true
+      }, {
+        dataIndex: 'update_frequency_code',
+        hideInTable: true
+      }, {
+        dataIndex: 'bounding_geometry',
+        hideInTable: true
+      }, {
+        dataIndex: 'dataset_id',
+        hideInTable: true
+      }, {
+        dataIndex: 'dataset_id_code_space',
+        hideInTable: true
+      }, {
+        dataIndex: 'inspire_interoperability',
+        hideInTable: true
+      }, {
+        key: 'actions',
+        title: 'Aktionen',
+        valueType: 'option',
+        render: (text: any, record:any) => {
+          return (
+            <>
+                <Button
+                  size='small'
+                  type='primary'
+                  onClick={ () => { addDatasetToMap(record); }}
+                >
+                  Zur Karte hinzufügen
+                </Button>
+            </>
+          );
+        }
+      }, {
+        dataIndex: 'search',
+        title: 'Suchbegriffe',
+        valueType: 'text',
+        hideInTable: true,
+        hideInSearch: false,
+        search : {
+          transform : buildSearchTransformText('search')
+        }
+      }
+    ];
+
+    return (
+      <>
+        <Button
+          ref={buttonRef}
+          size='large'
+          className={`drawer-toggle-btn ${visible ? 'expanded' : 'collapsed'}`}
+          onClick={(ev) => { setVisible(!visible); buttonRef.current?.blur(); }}
+        >
+          <PlusCircleOutlined />
+        </Button>
+        <Drawer
+          className='search-drawer'
+          placement='right'
+          width={1000}
+          visible={visible}
+          closable={false}
+          mask={false}
+        >
+          <RepoTable
+            repo={repo}
+            columns={columns}
+            pagination={{
+              defaultPageSize: 13,
+              showSizeChanger: true,
+              pageSizeOptions: ['10', '13', '20', '50', '100']
+            }}
+          />
+        </Drawer>
+      </>
+    );
+};

--- a/frontend/src/Components/Shared/Table/RepoTable.tsx
+++ b/frontend/src/Components/Shared/Table/RepoTable.tsx
@@ -36,7 +36,7 @@ export type RepoActionType = ActionType & {
 
 function augmentColumns (resourceSchema: any, queryParams: any,
   columnHints: ProColumnType[] | undefined): ProColumnType[] {
-  const props = resourceSchema.properties.data.items.properties.attributes.properties;
+  const props = resourceSchema.properties?.data?.items?.properties?.attributes?.properties;
   const columns:any = {};
   // phase 1: add a column for every column hint, merge with schema property definition (if available)
   if (columnHints) {

--- a/frontend/src/Repos/JsonApiRepo.ts
+++ b/frontend/src/Repos/JsonApiRepo.ts
@@ -126,6 +126,11 @@ class JsonApiRepo {
       return await client['List' + this.resourcePath](jsonApiParams);
     }
 
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    async create (create: any): Promise<JsonApiResponse> {
+      throw new Error('This method is abstract');
+    }
+
     async get (id: string): Promise<JsonApiResponse> {
       const client = await JsonApiRepo.getClientInstance();
       return await client['retrieve' + this.resourcePath + '{id}/'](id, {}, {

--- a/frontend/src/Repos/__mocks__/DatasetMetadataRepo.ts
+++ b/frontend/src/Repos/__mocks__/DatasetMetadataRepo.ts
@@ -1,0 +1,37 @@
+import OpenAPIClientAxios, { OpenAPIV3 } from 'openapi-client-axios';
+import DatasetsJson from './data/DatasetMetadata.json';
+// @ts-ignore
+import OpenApiSpec from './openapi.json';
+
+const api = new OpenAPIClientAxios({
+  definition: OpenApiSpec as OpenAPIV3.Document
+});
+api.init();
+
+const mock = jest.fn().mockImplementation(() => {
+  return {
+    getResourceSchema: () => {
+      const op = api.getOperation('List/api/v1/registry/dataset-metadata/' );
+      if (!op) {
+        return [];
+      }
+      const response: any = op.responses[200];
+      if (!response) {
+        return [];
+      }
+      const mimeType = response.content['application/vnd.api+json'];
+      if (!mimeType) {
+        return [];
+      }
+      return mimeType.schema;
+    },
+    getQueryParams: () => {
+      return {};
+    },
+    findAll: () => {
+      return DatasetsJson;
+    },
+  };
+});
+
+export default mock;

--- a/frontend/src/Repos/__mocks__/data/DatasetMetadata.json
+++ b/frontend/src/Repos/__mocks__/data/DatasetMetadata.json
@@ -1,0 +1,921 @@
+{
+  "links": {
+    "first": "https://localhost/api/v1/registry/dataset-metadata/?page%5Bnumber%5D=1&page%5Bsize%5D=13",
+    "last": "https://localhost/api/v1/registry/dataset-metadata/?page%5Bnumber%5D=4&page%5Bsize%5D=13",
+    "next": "https://localhost/api/v1/registry/dataset-metadata/?page%5Bnumber%5D=2&page%5Bsize%5D=13",
+    "prev": null
+  },
+  "data": [
+    {
+      "type": "DatasetMetadata",
+      "id": "fd778be1-2851-4cba-9549-1192fcc6f95f",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/fd778be1-2851-4cba-9549-1192fcc6f95f/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:15.664887+01:00",
+        "file_identifier": "04c4fa1d-f238-3576-c364-5750a2d1ed23",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=04c4fa1df2383576c3645750a2d1ed23",
+        "title": "Wohnen für ältere Menschen in Einrichtungen",
+        "abstract": "Wohnen für ältere Menschen mit Unterstützungs- oder Pflegebedarf in Einrichtungen",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "04c4fa1df2383576c3645750a2d1ed23",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "eecdc27e-eb79-420a-8fb1-8d1a9306fcde" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/fd778be1-2851-4cba-9549-1192fcc6f95f/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "c8a8b70a-5b75-475c-911d-fafb99932aaa",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/c8a8b70a-5b75-475c-911d-fafb99932aaa/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:15.744879+01:00",
+        "file_identifier": "663e7d42-b9af-a285-447a-e39e255485cd",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=663e7d42b9afa285447ae39e255485cd",
+        "title": "Krankenhäuser",
+        "abstract": "Krankenhäuser in Rheinland-Pfalz",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "663e7d42b9afa285447ae39e255485cd",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "ed51984b-d0e5-49b7-8b31-a890c54a1d5b" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/c8a8b70a-5b75-475c-911d-fafb99932aaa/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "b39215fd-0aef-423b-82f5-17c9f3eacc98",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/b39215fd-0aef-423b-82f5-17c9f3eacc98/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:15.814339+01:00",
+        "file_identifier": "eab231a0-33e1-4b76-11a7-755f89e2eb77",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=eab231a033e14b7611a7755f89e2eb77",
+        "title": "Betreutes Wohnen für ältere Menschen",
+        "abstract": "Betreutes Wohnen für ältere Menschen in Rheinland-Pfalz",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "eab231a033e14b7611a7755f89e2eb77",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "60f9bf22-ec0c-4a8a-8ee7-d685384ec680" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/b39215fd-0aef-423b-82f5-17c9f3eacc98/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "4134e398-249a-4b47-97ea-6218ea3d581f",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/4134e398-249a-4b47-97ea-6218ea3d581f/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:15.924468+01:00",
+        "file_identifier": "b053e9f9-3744-21a6-1f5b-9f00900d3502",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=b053e9f9374421a61f5b9f00900d3502",
+        "title": "Selbsthilfegruppen",
+        "abstract": "Hilfe zur Selbsthilfe im Gesundheitswesen",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "b053e9f9374421a61f5b9f00900d3502",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "f75e207b-5ade-484e-828c-8e4874680495" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/4134e398-249a-4b47-97ea-6218ea3d581f/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "8a9f54be-2f5a-4de0-9db7-bb0705d71620",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/8a9f54be-2f5a-4de0-9db7-bb0705d71620/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:15.906769+01:00",
+        "file_identifier": "77c4dcf4-b1a4-39a2-08d2-2464cced7b44",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=77c4dcf4b1a439a208d22464cced7b44",
+        "title": "Integrative Kindertagesstätten und Förderkindergärten",
+        "abstract": "Integrative Kindertagesstätten und Förderkindergärten in Rheinland-Pfalz",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "77c4dcf4b1a439a208d22464cced7b44",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "cc841c45-fa61-465f-9370-087bde2e9edd" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/8a9f54be-2f5a-4de0-9db7-bb0705d71620/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "02a27834-6c66-4fe5-8ad5-d01e179f9790",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/02a27834-6c66-4fe5-8ad5-d01e179f9790/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:16.082605+01:00",
+        "file_identifier": "19cfb1a3-b35d-c15f-ac47-b11602fc7489",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=19cfb1a3b35dc15fac47b11602fc7489",
+        "title": "Einrichtungen für Menschen mit Behinderung",
+        "abstract": "Wohnangebote für Menschen mit Behinderung",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "19cfb1a3b35dc15fac47b11602fc7489",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "a91c1395-4a9d-4cd7-ae22-3b8bf6b5529b" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/02a27834-6c66-4fe5-8ad5-d01e179f9790/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "2df5dfb6-18ba-4465-9d17-e3b88cd298e1",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/2df5dfb6-18ba-4465-9d17-e3b88cd298e1/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:16.181871+01:00",
+        "file_identifier": "1b5b9006-a52a-96c1-6678-e0c5f5c66776",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=1b5b9006a52a96c16678e0c5f5c66776",
+        "title": "Werkstätten für behinderte Menschen",
+        "abstract": "Werkstätten für behinderte Menschen in Rheinland-Pfalz",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "1b5b9006a52a96c16678e0c5f5c66776",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "31fe14e3-9dfb-40c4-b371-df3480b84659" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/2df5dfb6-18ba-4465-9d17-e3b88cd298e1/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "bd0391b3-a217-4175-8182-89bad9290d9f",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/bd0391b3-a217-4175-8182-89bad9290d9f/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:16.182802+01:00",
+        "file_identifier": "563fa1b1-9067-af30-cd15-e6e89725b950",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=563fa1b19067af30cd15e6e89725b950",
+        "title": "Pflegestützpunkte",
+        "abstract": "Pflegestützpunkte in Rheinland-Pfalz",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "563fa1b19067af30cd15e6e89725b950",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "111181c7-e67d-4c93-bffa-9bf791634a2c" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/bd0391b3-a217-4175-8182-89bad9290d9f/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "0c27218f-55fe-4872-bd28-b7efe5c8101d",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/0c27218f-55fe-4872-bd28-b7efe5c8101d/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:16.352840+01:00",
+        "file_identifier": "e395d054-d1ea-b2d9-adda-d9bc25c115a0",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=e395d054d1eab2d9addad9bc25c115a0",
+        "title": "Suchtberatungsstellen",
+        "abstract": "Beratung und Betreuung für Betroffene und Angehörige ",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "e395d054d1eab2d9addad9bc25c115a0",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "14f7bd40-93e1-4ed3-a026-b424d45db3e8" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/0c27218f-55fe-4872-bd28-b7efe5c8101d/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "5b375431-8fa4-4bec-8dab-bdce011dd4ad",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/5b375431-8fa4-4bec-8dab-bdce011dd4ad/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:16.384992+01:00",
+        "file_identifier": "ebca6293-0c10-868e-c1da-84ef27586307",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=ebca62930c10868ec1da84ef27586307",
+        "title": "Frühförderzentren",
+        "abstract": "Frühförderung von Kindern mit besonderem Unterstützungsbedarf",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "ebca62930c10868ec1da84ef27586307",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "39dc1bf8-c4c6-49db-a89f-f1dea95876df" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/5b375431-8fa4-4bec-8dab-bdce011dd4ad/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "d058c84e-5d41-4f29-9198-f3d8ea2de020",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/d058c84e-5d41-4f29-9198-f3d8ea2de020/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:16.520155+01:00",
+        "file_identifier": "7368f457-159e-8bf5-aed1-24a89fdbeee1",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=7368f457159e8bf5aed124a89fdbeee1",
+        "title": "Schuldnerberatungsstellen",
+        "abstract": "Hilfe und Unterstützung bei Schuldenproblemen",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "7368f457159e8bf5aed124a89fdbeee1",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "82fd4b91-5eaf-4e43-9019-02bb7ef16681" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/d058c84e-5d41-4f29-9198-f3d8ea2de020/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "2812a204-91c2-4b28-9b8b-de370df16b08",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/2812a204-91c2-4b28-9b8b-de370df16b08/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:16.524331+01:00",
+        "file_identifier": "e9dea522-000b-7a84-0f05-a56d64aef1d2",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=e9dea522000b7a840f05a56d64aef1d2",
+        "title": "Fachkliniken für Suchtkranke",
+        "abstract": "Fachkliniken für Suchtkranke",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "e9dea522000b7a840f05a56d64aef1d2",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "e62bda9c-a2db-44fb-b609-542e6f487b9f" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/2812a204-91c2-4b28-9b8b-de370df16b08/"
+      }
+    },
+    {
+      "type": "DatasetMetadata",
+      "id": "3f027b5b-67a8-4ddc-8914-7e0bbae915c1",
+      "attributes": {
+        "xml_backup_file": "https://localhost/xml_documents/3f027b5b-67a8-4ddc-8914-7e0bbae915c1/md_metadata.xml",
+        "access_constraints": "Datenlizenz Deutschland – Namensnennung – Version 2.0; URL: https://www.govdata.de/dl-de/by-2-0 Die Namensnennung des Landes Rheinland-Pfalz als Rechteinhaber hat in folgender Weise zu erfolgen: Rheinland-Pfalz <Jahr des Datenbezugs>, dl-de/by-2-0, http://www.rlp.de [Daten bearbeitet];",
+        "fees": null,
+        "use_limitation": null,
+        "license_source_note": null,
+        "date_stamp": "2022-01-03T15:47:16.629458+01:00",
+        "file_identifier": "929ffe39-2272-38cf-0f0d-28c98efd3c92",
+        "origin": "iso metadata",
+        "origin_url": "https://gis.mffjiv.rlp.de/cgi-scripts/datasetMetadata.php?id=929ffe39227238cf0f0d28c98efd3c92",
+        "title": "Soziotherapeutische Einrichtungen für Suchtkranke",
+        "abstract": "Soziotherapeutische Einrichtungen für Suchtkranke",
+        "is_broken": false,
+        "is_customized": true,
+        "insufficient_quality": null,
+        "is_searchable": false,
+        "hits": 0,
+        "spatial_res_type": null,
+        "spatial_res_value": null,
+        "format": null,
+        "charset": null,
+        "inspire_top_consistence": false,
+        "preview_image": null,
+        "lineage_statement": null,
+        "update_frequency_code": null,
+        "bounding_geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [6.03777, 48.898],
+                [6.03777, 51.0009],
+                [8.6177, 51.0009],
+                [8.6177, 48.898],
+                [6.03777, 48.898]
+              ]
+            ]
+          ]
+        },
+        "dataset_id": "929ffe39227238cf0f0d28c98efd3c92",
+        "dataset_id_code_space": "https://msagd.rlp.de/registry/spatial/dataset/",
+        "inspire_interoperability": false
+      },
+      "relationships": {
+        "licence": { "data": null },
+        "dataset_contact": { "data": { "type": "MetadataContact", "id": "2" } },
+        "metadata_contact": {
+          "data": { "type": "MetadataContact", "id": "2" }
+        },
+        "keywords": { "meta": { "count": 0 }, "data": [] },
+        "reference_systems": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_layers": {
+          "meta": { "count": 1 },
+          "data": [
+            { "type": "Layer", "id": "e854eae1-56f6-493d-887d-2fe5c791ea40" }
+          ]
+        },
+        "self_pointing_feature_types": { "meta": { "count": 0 }, "data": [] },
+        "self_pointing_catalouge_service": {
+          "meta": { "count": 0 },
+          "data": []
+        }
+      },
+      "links": {
+        "self": "https://localhost/api/v1/registry/dataset-metadata/3f027b5b-67a8-4ddc-8914-7e0bbae915c1/"
+      }
+    }
+  ],
+  "meta": { "pagination": { "page": 1, "pages": 4, "count": 42 } }
+}

--- a/frontend/src/Repos/__mocks__/openapi.json
+++ b/frontend/src/Repos/__mocks__/openapi.json
@@ -1,0 +1,25141 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "MrMap JSON:API",
+    "version": "1.0.0",
+    "description": "API for all things …"
+  },
+  "paths": {
+    "/api/v1/registry/wms/": {
+      "get": {
+        "operationId": "List/api/v1/registry/wms/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/wms/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/WebMapService"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wms/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "get_capabilities_url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "the capabilities url of the ogc service",
+                            "maxLength": 4096,
+                            "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+                          },
+                          "collect_metadata_records": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "required": [
+                          "get_capabilities_url"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "owner": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "service_auth": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/WebMapServiceCreate"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wms/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web map service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wms/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/WebMapService"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/wms/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web map service.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "access_constraints": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "access constraints for the given resource."
+                          },
+                          "fees": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Costs and of terms of use for the given resource."
+                          },
+                          "use_limitation": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "license_source_note": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          },
+                          "get_capabilities_url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "the capabilities url of the ogc service",
+                            "maxLength": 4096,
+                            "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "layers": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service_contact": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "metadata_contact": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "created_by": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "last_modified_by": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "licence": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/wms/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/WebMapService"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wms/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web map service.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{parent_lookup_service}/layers/": {
+      "get": {
+        "operationId": "List/api/v1/registry/wms/{parent_lookup_service}/layers/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/wms/{parent_lookup_service}/layers/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Layer"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wms/{parent_lookup_service}/layers/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "bbox_lat_lon": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          }
+                        },
+                        "required": [
+                          "bbox_lat_lon",
+                          "title"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "styles": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "parent": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Layer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{parent_lookup_service}/layers/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wms/{parent_lookup_service}/layers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wms/{parent_lookup_service}/layers/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Layer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/wms/{parent_lookup_service}/layers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "bbox_lat_lon": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "styles": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "parent": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/wms/{parent_lookup_service}/layers/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Layer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wms/{parent_lookup_service}/layers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/": {
+      "get": {
+        "operationId": "List/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MetadataContact"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the organization",
+                            "maxLength": 256
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 100
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the organization",
+                            "maxLength": 256
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 100
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wms/{parent_lookup_service_contact_webmapservice_metadata}/service-contact/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/": {
+      "get": {
+        "operationId": "List/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_metadata_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MetadataContact"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_metadata_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the organization",
+                            "maxLength": 256
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 100
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_metadata_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_metadata_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the organization",
+                            "maxLength": 256
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 100
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wms/{parent_lookup_metadata_contact_webmapservice_metadata}/service-contact/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_metadata_contact_webmapservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/": {
+      "get": {
+        "operationId": "List/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_ogcservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Keyword"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_ogcservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "keyword": {
+                            "type": "string",
+                            "maxLength": 255
+                          }
+                        },
+                        "required": [
+                          "keyword"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_ogcservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_ogcservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "keyword": {
+                            "type": "string",
+                            "maxLength": 255
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wms/{parent_lookup_ogcservice_metadata}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_ogcservice_metadata",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/layers/": {
+      "get": {
+        "operationId": "List/api/v1/registry/layers/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/layers/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Layer"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/layers/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "bbox_lat_lon": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          }
+                        },
+                        "required": [
+                          "bbox_lat_lon",
+                          "title"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "styles": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "parent": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Layer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/layers/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/layers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/layers/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Layer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/layers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "bbox_lat_lon": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "styles": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "parent": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/layers/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Layer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/layers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/layers/{parent_lookup_layer}/styles/": {
+      "get": {
+        "operationId": "List/api/v1/registry/layers/{parent_lookup_layer}/styles/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/layers/{parent_lookup_layer}/styles/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Style"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/layers/{parent_lookup_layer}/styles/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {}
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Style"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/layers/{parent_lookup_layer}/styles/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/layers/{parent_lookup_layer}/styles/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this style.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/layers/{parent_lookup_layer}/styles/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Style"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/layers/{parent_lookup_layer}/styles/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this style.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {}
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/layers/{parent_lookup_layer}/styles/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Style"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/layers/{parent_lookup_layer}/styles/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this style.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/layers/{parent_lookup_layer}/keywords/": {
+      "get": {
+        "operationId": "List/api/v1/registry/layers/{parent_lookup_layer}/keywords/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/layers/{parent_lookup_layer}/keywords/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Keyword"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/layers/{parent_lookup_layer}/keywords/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "keyword": {
+                            "type": "string",
+                            "maxLength": 255
+                          }
+                        },
+                        "required": [
+                          "keyword"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/layers/{parent_lookup_layer}/keywords/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/layers/{parent_lookup_layer}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/layers/{parent_lookup_layer}/keywords/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/layers/{parent_lookup_layer}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "keyword": {
+                            "type": "string",
+                            "maxLength": 255
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/layers/{parent_lookup_layer}/keywords/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/layers/{parent_lookup_layer}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_layer",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wfs/": {
+      "get": {
+        "operationId": "List/api/v1/registry/wfs/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/wfs/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/WebFeatureService"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wfs/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "get_capabilities_url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "the capabilities url of the ogc service",
+                            "maxLength": 4096,
+                            "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+                          },
+                          "collect_metadata_records": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "required": [
+                          "get_capabilities_url"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "owner": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "service_auth": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/WebFeatureServiceCreate"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wfs/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wfs/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web feature service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wfs/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/WebFeatureService"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/wfs/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web feature service.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "access_constraints": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "access constraints for the given resource."
+                          },
+                          "fees": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Costs and of terms of use for the given resource."
+                          },
+                          "use_limitation": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "license_source_note": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          },
+                          "get_capabilities_url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "the capabilities url of the ogc service",
+                            "maxLength": 4096,
+                            "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "featuretypes": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "licence": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "service_contact": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "metadata_contact": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/wfs/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/WebFeatureService"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wfs/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web feature service.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/": {
+      "get": {
+        "operationId": "List/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FeatureType"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          },
+                          "describe_feature_type_document": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "the fetched content of the download describe feature type document."
+                          }
+                        },
+                        "required": [
+                          "title"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "output_formats": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/FeatureType"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/FeatureType"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          },
+                          "describe_feature_type_document": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "the fetched content of the download describe feature type document."
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "output_formats": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/FeatureType"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wfs/{parent_lookup_service}/featuretypes/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_service",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/featuretypes/": {
+      "get": {
+        "operationId": "List/api/v1/registry/featuretypes/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/featuretypes/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FeatureType"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/featuretypes/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          },
+                          "describe_feature_type_document": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "the fetched content of the download describe feature type document."
+                          }
+                        },
+                        "required": [
+                          "title"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "output_formats": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/FeatureType"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/featuretypes/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/featuretypes/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/featuretypes/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/FeatureType"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/featuretypes/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+                          },
+                          "describe_feature_type_document": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "the fetched content of the download describe feature type document."
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "service": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "output_formats": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/featuretypes/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/FeatureType"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/featuretypes/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/": {
+      "get": {
+        "operationId": "List/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_featuretype",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Keyword"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_featuretype",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "keyword": {
+                            "type": "string",
+                            "maxLength": 255
+                          }
+                        },
+                        "required": [
+                          "keyword"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_featuretype",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_featuretype",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "keyword": {
+                            "type": "string",
+                            "maxLength": 255
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/featuretypes/{parent_lookup_featuretype}/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_featuretype",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontexts/": {
+      "get": {
+        "operationId": "List/api/v1/registry/mapcontexts/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/mapcontexts/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MapContextDefault"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/mapcontexts/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this map context",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the topic of this map context"
+                          }
+                        },
+                        "required": [
+                          "title"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "map_context_layers": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextDefault"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontexts/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/mapcontexts/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/mapcontexts/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextDefault"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/mapcontexts/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this map context",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the topic of this map context"
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "map_context_layers": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/mapcontexts/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextDefault"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/mapcontexts/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/": {
+      "get": {
+        "operationId": "List/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_map_context",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MapContextLayer"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_map_context",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "an identifying name for this map context layer",
+                            "maxLength": 1000
+                          },
+                          "title": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "a short descriptive title for this map context layer",
+                            "maxLength": 1000
+                          },
+                          "layer_scale_min": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "minimum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+                          },
+                          "layer_scale_max": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "maximum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true,
+                            "description": "A preview image for the Map Context Layer"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "parent": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "map_context": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "dataset_metadata": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "rendering_layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "layer_style": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "selection_layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextLayer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_map_context",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextLayer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_map_context",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "an identifying name for this map context layer",
+                            "maxLength": 1000
+                          },
+                          "title": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "a short descriptive title for this map context layer",
+                            "maxLength": 1000
+                          },
+                          "layer_scale_min": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "minimum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+                          },
+                          "layer_scale_max": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "maximum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true,
+                            "description": "A preview image for the Map Context Layer"
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "parent": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "map_context": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "dataset_metadata": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "rendering_layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "layer_style": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "selection_layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextLayer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_map_context",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontextlayers/": {
+      "get": {
+        "operationId": "List/api/v1/registry/mapcontextlayers/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/mapcontextlayers/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MapContextLayer"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/mapcontextlayers/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "an identifying name for this map context layer",
+                            "maxLength": 1000
+                          },
+                          "title": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "a short descriptive title for this map context layer",
+                            "maxLength": 1000
+                          },
+                          "layer_scale_min": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "minimum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+                          },
+                          "layer_scale_max": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "maximum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true,
+                            "description": "A preview image for the Map Context Layer"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "parent": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "map_context": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "dataset_metadata": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "rendering_layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "layer_style": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "selection_layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextLayer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontextlayers/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/mapcontextlayers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/mapcontextlayers/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextLayer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/mapcontextlayers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "an identifying name for this map context layer",
+                            "maxLength": 1000
+                          },
+                          "title": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "a short descriptive title for this map context layer",
+                            "maxLength": 1000
+                          },
+                          "layer_scale_min": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "minimum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+                          },
+                          "layer_scale_max": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "maximum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true,
+                            "description": "A preview image for the Map Context Layer"
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "parent": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "map_context": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "dataset_metadata": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "rendering_layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "layer_style": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "selection_layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/mapcontextlayers/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextLayer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/mapcontextlayers/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/keywords/": {
+      "get": {
+        "operationId": "List/api/v1/registry/keywords/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/keywords/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Keyword"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/keywords/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "keyword": {
+                            "type": "string",
+                            "maxLength": 255
+                          }
+                        },
+                        "required": [
+                          "keyword"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/keywords/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/keywords/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "keyword": {
+                            "type": "string",
+                            "maxLength": 255
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/keywords/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Keyword"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/keywords/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this keyword.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/styles/": {
+      "get": {
+        "operationId": "List/api/v1/registry/styles/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/styles/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Style"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/styles/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {}
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Style"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/styles/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/styles/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this style.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/styles/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Style"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/styles/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this style.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {}
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "layer": {
+                            "$ref": "#/components/schemas/reltoone"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/styles/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Style"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/styles/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this style.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/dataset-metadata/": {
+      "get": {
+        "operationId": "List/api/v1/registry/dataset-metadata/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keywords.keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keywords__keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keywords.keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keywords__keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keywords.keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keywords__keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/dataset-metadata/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DatasetMetadata"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/dataset-metadata/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "access_constraints": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "access constraints for the given resource."
+                          },
+                          "fees": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Costs and of terms of use for the given resource."
+                          },
+                          "use_limitation": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "license_source_note": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "spatial_res_type": {
+                            "enum": [
+                              "groundDistance",
+                              "scaleDenominator"
+                            ],
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Ground resolution in meter or the equivalent scale."
+                          },
+                          "spatial_res_value": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "The value depending on the selected resolution type."
+                          },
+                          "format": {
+                            "enum": [
+                              null,
+                              "Database",
+                              "Esri shape",
+                              "CSV",
+                              "GML",
+                              "GeoTIFF"
+                            ],
+                            "nullable": true,
+                            "description": "The format in which the described dataset is stored."
+                          },
+                          "charset": {
+                            "enum": [
+                              null,
+                              "utf8"
+                            ],
+                            "nullable": true,
+                            "description": "The charset which is used by the stored data."
+                          },
+                          "inspire_top_consistence": {
+                            "type": "boolean",
+                            "description": "Flag to signal if the described data has a topologically consistence."
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true
+                          },
+                          "lineage_statement": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "update_frequency_code": {
+                            "enum": [
+                              "annually",
+                              "asNeeded",
+                              "biannually",
+                              "irregular",
+                              "notPlanned",
+                              "unknown"
+                            ],
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "bounding_geometry": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "dataset_id": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "identifier of the remote data",
+                            "maxLength": 4096
+                          },
+                          "dataset_id_code_space": {
+                            "type": "string",
+                            "description": "code space for the given identifier",
+                            "maxLength": 4096
+                          },
+                          "inspire_interoperability": {
+                            "type": "boolean",
+                            "description": "flag to signal if this "
+                          }
+                        },
+                        "required": [
+                          "title"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "licence": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "dataset_contact": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "metadata_contact": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "self_pointing_layers": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "self_pointing_feature_types": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "self_pointing_catalouge_service": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/DatasetMetadata"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/dataset-metadata/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/dataset-metadata/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this dataset metadata.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keywords.keyword]",
+            "required": false,
+            "in": "query",
+            "description": "keywords__keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keywords.keyword.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "keywords__keyword__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[keywords.keyword.contains]",
+            "required": false,
+            "in": "query",
+            "description": "keywords__keyword__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/dataset-metadata/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/DatasetMetadata"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/dataset-metadata/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this dataset metadata.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "access_constraints": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "access constraints for the given resource."
+                          },
+                          "fees": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Costs and of terms of use for the given resource."
+                          },
+                          "use_limitation": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "license_source_note": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "a short descriptive title for this metadata",
+                            "maxLength": 1000
+                          },
+                          "abstract": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "brief summary of the content of this metadata."
+                          },
+                          "insufficient_quality": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "TODO"
+                          },
+                          "is_searchable": {
+                            "type": "boolean",
+                            "description": "only searchable metadata will be returned from the search api"
+                          },
+                          "spatial_res_type": {
+                            "enum": [
+                              "groundDistance",
+                              "scaleDenominator"
+                            ],
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Ground resolution in meter or the equivalent scale."
+                          },
+                          "spatial_res_value": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "The value depending on the selected resolution type."
+                          },
+                          "format": {
+                            "enum": [
+                              null,
+                              "Database",
+                              "Esri shape",
+                              "CSV",
+                              "GML",
+                              "GeoTIFF"
+                            ],
+                            "nullable": true,
+                            "description": "The format in which the described dataset is stored."
+                          },
+                          "charset": {
+                            "enum": [
+                              null,
+                              "utf8"
+                            ],
+                            "nullable": true,
+                            "description": "The charset which is used by the stored data."
+                          },
+                          "inspire_top_consistence": {
+                            "type": "boolean",
+                            "description": "Flag to signal if the described data has a topologically consistence."
+                          },
+                          "preview_image": {
+                            "type": "string",
+                            "format": "binary",
+                            "nullable": true
+                          },
+                          "lineage_statement": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "update_frequency_code": {
+                            "enum": [
+                              "annually",
+                              "asNeeded",
+                              "biannually",
+                              "irregular",
+                              "notPlanned",
+                              "unknown"
+                            ],
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "bounding_geometry": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "dataset_id": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "identifier of the remote data",
+                            "maxLength": 4096
+                          },
+                          "dataset_id_code_space": {
+                            "type": "string",
+                            "description": "code space for the given identifier",
+                            "maxLength": 4096
+                          },
+                          "inspire_interoperability": {
+                            "type": "boolean",
+                            "description": "flag to signal if this "
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "licence": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "dataset_contact": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "metadata_contact": {
+                            "$ref": "#/components/schemas/reltoone"
+                          },
+                          "keywords": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "reference_systems": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "self_pointing_layers": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "self_pointing_feature_types": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "self_pointing_catalouge_service": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/dataset-metadata/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/DatasetMetadata"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/dataset-metadata/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this dataset metadata.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/metadata-contacts/": {
+      "get": {
+        "operationId": "List/api/v1/registry/metadata-contacts/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/registry/metadata-contacts/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MetadataContact"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/metadata-contacts/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the organization",
+                            "maxLength": 256
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 100
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/metadata-contacts/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/metadata-contacts/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/metadata-contacts/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/registry/metadata-contacts/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the organization",
+                            "maxLength": 256
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 100
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/registry/metadata-contacts/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MetadataContact"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/metadata-contacts/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this metadata contact.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/layers/{layer_pk}/service": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/layers/{layer_pk}/service",
+        "description": "",
+        "parameters": [
+          {
+            "name": "layer_pk",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title]",
+            "required": false,
+            "in": "query",
+            "description": "title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "title__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[title.contains]",
+            "required": false,
+            "in": "query",
+            "description": "title__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract]",
+            "required": false,
+            "in": "query",
+            "description": "abstract",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[abstract.contains]",
+            "required": false,
+            "in": "query",
+            "description": "abstract__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.contains]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.covers]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__covers",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.equals]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__equals",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[bbox_lat_lon.intersects]",
+            "required": false,
+            "in": "query",
+            "description": "bbox_lat_lon__intersects",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/layers/{layer_pk}/service",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/WebMapService"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wms/{id}/relationships/{related_field}": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wms/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web map service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wms/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wms/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web map service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partialUpdate/api/v1/registry/wms/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web map service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partialUpdate/api/v1/registry/wms/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wms/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web map service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/layers/{id}/relationships/{related_field}": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/layers/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/layers/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/layers/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partialUpdate/api/v1/registry/layers/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partialUpdate/api/v1/registry/layers/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/layers/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebMapService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/wfs/{id}/relationships/{related_field}": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/wfs/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web feature service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/wfs/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/wfs/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web feature service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partialUpdate/api/v1/registry/wfs/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web feature service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partialUpdate/api/v1/registry/wfs/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/wfs/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this web feature service.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/featuretypes/{id}/relationships/{related_field}": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/featuretypes/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/featuretypes/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/featuretypes/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partialUpdate/api/v1/registry/featuretypes/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partialUpdate/api/v1/registry/featuretypes/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/featuretypes/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this feature type.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebFeatureService"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontexts/{id}relationships/{related_field}": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/mapcontexts/{id}relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/mapcontexts/{id}relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/mapcontexts/{id}relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partialUpdate/api/v1/registry/mapcontexts/{id}relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partialUpdate/api/v1/registry/mapcontexts/{id}relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/mapcontexts/{id}relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontextlayers/{id}relationships/{related_field}": {
+      "get": {
+        "operationId": "retrieve/api/v1/registry/mapcontextlayers/{id}relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/registry/mapcontextlayers/{id}relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/registry/mapcontextlayers/{id}relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partialUpdate/api/v1/registry/mapcontextlayers/{id}relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partialUpdate/api/v1/registry/mapcontextlayers/{id}relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/registry/mapcontextlayers/{id}relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/users/": {
+      "get": {
+        "operationId": "List/api/v1/accounts/users/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/accounts/users/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/User"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/accounts/users/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "username": {
+                            "type": "string",
+                            "description": "Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+                            "pattern": "^[\\w.@+-]+\\z",
+                            "maxLength": 150
+                          },
+                          "password": {
+                            "type": "string",
+                            "maxLength": 128
+                          }
+                        },
+                        "required": [
+                          "username",
+                          "password"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "groups": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/UserCreate"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/users/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/accounts/users/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this User.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/accounts/users/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/User"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/accounts/users/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this User.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "last_login": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true
+                          },
+                          "is_superuser": {
+                            "type": "boolean",
+                            "description": "Designates that this user has all permissions without explicitly assigning them."
+                          },
+                          "username": {
+                            "type": "string",
+                            "description": "Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+                            "pattern": "^[\\w.@+-]+\\z",
+                            "maxLength": 150
+                          },
+                          "first_name": {
+                            "type": "string",
+                            "maxLength": 150
+                          },
+                          "last_name": {
+                            "type": "string",
+                            "maxLength": 150
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 254
+                          },
+                          "is_staff": {
+                            "type": "boolean",
+                            "description": "Designates whether the user can log into this admin site."
+                          },
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Designates whether this user should be treated as active. Unselect this instead of deleting accounts."
+                          },
+                          "date_joined": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "confirmed_newsletter": {
+                            "type": "boolean"
+                          },
+                          "confirmed_survey": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "groups": {
+                            "$ref": "#/components/schemas/reltomany"
+                          },
+                          "user_permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/accounts/users/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/User"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/accounts/users/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this User.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/users/{parent_lookup_user}/groups/": {
+      "get": {
+        "operationId": "List/api/v1/accounts/users/{parent_lookup_user}/groups/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/accounts/users/{parent_lookup_user}/groups/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Group"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/accounts/users/{parent_lookup_user}/groups/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "maxLength": 150
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Group"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/users/{parent_lookup_user}/groups/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/accounts/users/{parent_lookup_user}/groups/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this group.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/accounts/users/{parent_lookup_user}/groups/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Group"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/accounts/users/{parent_lookup_user}/groups/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this group.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "maxLength": 150
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/accounts/users/{parent_lookup_user}/groups/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Group"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/accounts/users/{parent_lookup_user}/groups/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this group.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/users/{parent_lookup_user}/organizations/": {
+      "get": {
+        "operationId": "List/api/v1/accounts/users/{parent_lookup_user}/organizations/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description]",
+            "required": false,
+            "in": "query",
+            "description": "description",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "description__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description.contains]",
+            "required": false,
+            "in": "query",
+            "description": "description__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_has_perm]",
+            "required": false,
+            "in": "query",
+            "description": "user_has_perm",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/accounts/users/{parent_lookup_user}/organizations/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Organization"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/accounts/users/{parent_lookup_user}/organizations/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "maxLength": 150
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Describe what this organization representing"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Organization"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/users/{parent_lookup_user}/organizations/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/accounts/users/{parent_lookup_user}/organizations/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this Organization.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description]",
+            "required": false,
+            "in": "query",
+            "description": "description",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "description__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description.contains]",
+            "required": false,
+            "in": "query",
+            "description": "description__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_has_perm]",
+            "required": false,
+            "in": "query",
+            "description": "user_has_perm",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/accounts/users/{parent_lookup_user}/organizations/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Organization"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/accounts/users/{parent_lookup_user}/organizations/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this Organization.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "maxLength": 150
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Describe what this organization representing"
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/accounts/users/{parent_lookup_user}/organizations/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Organization"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/accounts/users/{parent_lookup_user}/organizations/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_user",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this Organization.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/groups/": {
+      "get": {
+        "operationId": "List/api/v1/accounts/groups/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/accounts/groups/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Group"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/accounts/groups/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "maxLength": 150
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Group"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/groups/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/accounts/groups/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this group.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/accounts/groups/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Group"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/accounts/groups/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this group.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "maxLength": 150
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/accounts/groups/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Group"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/accounts/groups/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this group.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/organizations/": {
+      "get": {
+        "operationId": "List/api/v1/accounts/organizations/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description]",
+            "required": false,
+            "in": "query",
+            "description": "description",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "description__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description.contains]",
+            "required": false,
+            "in": "query",
+            "description": "description__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_has_perm]",
+            "required": false,
+            "in": "query",
+            "description": "user_has_perm",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/accounts/organizations/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Organization"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/accounts/organizations/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "maxLength": 150
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Describe what this organization representing"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Organization"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/organizations/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/accounts/organizations/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this Organization.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description]",
+            "required": false,
+            "in": "query",
+            "description": "description",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "description__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[description.contains]",
+            "required": false,
+            "in": "query",
+            "description": "description__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_has_perm]",
+            "required": false,
+            "in": "query",
+            "description": "user_has_perm",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/accounts/organizations/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Organization"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partial_update/api/v1/accounts/organizations/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this Organization.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "maxLength": 150
+                          },
+                          "person_name": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 200
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "phone": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "facsimile": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "postal_code": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "address_type": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "address": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "state_or_province": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "country": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Describe what this organization representing"
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "permissions": {
+                            "$ref": "#/components/schemas/reltomany"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partial_update/api/v1/accounts/organizations/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Organization"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/accounts/organizations/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this Organization.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/permissions/": {
+      "get": {
+        "operationId": "List/api/v1/accounts/permissions/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[codename]",
+            "required": false,
+            "in": "query",
+            "description": "codename",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[codename.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "codename__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/accounts/permissions/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Permission"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/permissions/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/accounts/permissions/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this permission.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name]",
+            "required": false,
+            "in": "query",
+            "description": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[codename]",
+            "required": false,
+            "in": "query",
+            "description": "codename",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[codename.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "codename__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/accounts/permissions/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Permission"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/users/{id}/relationships/{related_field}": {
+      "get": {
+        "operationId": "retrieve/api/v1/accounts/users/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this User.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/accounts/users/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create/api/v1/accounts/users/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this User.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "partialUpdate/api/v1/accounts/users/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this User.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "partialUpdate/api/v1/accounts/users/{id}/relationships/{related_field}",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceIdentifierObject"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroy/api/v1/accounts/users/{id}/relationships/{related_field}",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A UUID string identifying this User.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "related_field",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/ResourceIdentifierObject"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/onlymeta"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notify/task-results/": {
+      "get": {
+        "operationId": "List/api/v1/notify/task-results/",
+        "description": "",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "page[number]",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[task_name]",
+            "required": false,
+            "in": "query",
+            "description": "task_name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[task_name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "task_name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[task_name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "task_name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status]",
+            "required": false,
+            "in": "query",
+            "description": "status",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "FAILURE",
+                "PENDING",
+                "RECEIVED",
+                "RETRY",
+                "REVOKED",
+                "STARTED",
+                "SUCCESS"
+              ]
+            }
+          },
+          {
+            "name": "filter[date_created]",
+            "required": false,
+            "in": "query",
+            "description": "date_created",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[date_created.gt]",
+            "required": false,
+            "in": "query",
+            "description": "date_created__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[date_created.lt]",
+            "required": false,
+            "in": "query",
+            "description": "date_created__lt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[date_created.range]",
+            "required": false,
+            "in": "query",
+            "description": "date_created__range",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "api"
+        ],
+        "responses": {
+          "200": {
+            "description": "List/api/v1/notify/task-results/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/TaskResult"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notify/task-results/{id}/": {
+      "get": {
+        "operationId": "retrieve/api/v1/notify/task-results/{id}/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this task result.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/include"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          },
+          {
+            "$ref": "#/components/parameters/sort"
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "description": "Which field to use when ordering the results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[task_name]",
+            "required": false,
+            "in": "query",
+            "description": "task_name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[task_name.icontains]",
+            "required": false,
+            "in": "query",
+            "description": "task_name__icontains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[task_name.contains]",
+            "required": false,
+            "in": "query",
+            "description": "task_name__contains",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status]",
+            "required": false,
+            "in": "query",
+            "description": "status",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "FAILURE",
+                "PENDING",
+                "RECEIVED",
+                "RETRY",
+                "REVOKED",
+                "STARTED",
+                "SUCCESS"
+              ]
+            }
+          },
+          {
+            "name": "filter[date_created]",
+            "required": false,
+            "in": "query",
+            "description": "date_created",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[date_created.gt]",
+            "required": false,
+            "in": "query",
+            "description": "date_created__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[date_created.lt]",
+            "required": false,
+            "in": "query",
+            "description": "date_created__lt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[date_created.range]",
+            "required": false,
+            "in": "query",
+            "description": "date_created__range",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[search]",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "api"
+        ],
+        "responses": {
+          "200": {
+            "description": "retrieve/api/v1/notify/task-results/{id}/",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/TaskResult"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/{id}/move_to/": {
+      "post": {
+        "operationId": "move_to/api/v1/registry/mapcontexts/{parent_lookup_map_context}/mapcontextlayers/{id}/move_to/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "parent_lookup_map_context",
+            "in": "path",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "target": {
+                            "type": "integer"
+                          },
+                          "position": {
+                            "enum": [
+                              "first-child",
+                              "last-child",
+                              "left",
+                              "right"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "target",
+                          "position"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextLayerMoveLayer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/mapcontextlayers/{id}/move_to/": {
+      "post": {
+        "operationId": "move_to/api/v1/registry/mapcontextlayers/{id}/move_to/",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "A unique integer value identifying this map context layer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "MapContext"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "target": {
+                            "type": "integer"
+                          },
+                          "position": {
+                            "enum": [
+                              "first-child",
+                              "last-child",
+                              "left",
+                              "right"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "target",
+                          "position"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MapContextLayerMoveLayer"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/login/": {
+      "post": {
+        "operationId": "create/api/v1/accounts/login/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "username": {
+                            "type": "string"
+                          },
+                          "password": {
+                            "type": "string",
+                            "writeOnly": true
+                          }
+                        },
+                        "required": [
+                          "username",
+                          "password"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Login"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/logout/": {
+      "post": {
+        "operationId": "create/api/v1/accounts/logout/",
+        "description": "",
+        "parameters": [],
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "$ref": "#/components/schemas/type"
+                      },
+                      "id": {
+                        "$ref": "#/components/schemas/id"
+                      },
+                      "links": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "$ref": "#/components/schemas/link"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Logout"
+                    },
+                    "included": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/components/schemas/resource"
+                      }
+                    },
+                    "links": {
+                      "description": "Link members related to primary data",
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/links"
+                        },
+                        {
+                          "$ref": "#/components/schemas/pagination"
+                        }
+                      ]
+                    },
+                    "jsonapi": {
+                      "$ref": "#/components/schemas/jsonapi"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datum"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+          },
+          "401": {
+            "description": "not authorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "jsonapi": {
+        "type": "object",
+        "description": "The server's implementation",
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        },
+        "additionalProperties": false
+      },
+      "resource": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "attributes": {
+            "type": "object"
+          },
+          "relationships": {
+            "type": "object"
+          },
+          "links": {
+            "$ref": "#/components/schemas/links"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        }
+      },
+      "link": {
+        "oneOf": [
+          {
+            "description": "a string containing the link's URL",
+            "type": "string",
+            "format": "uri-reference"
+          },
+          {
+            "type": "object",
+            "required": [
+              "href"
+            ],
+            "properties": {
+              "href": {
+                "description": "a string containing the link's URL",
+                "type": "string",
+                "format": "uri-reference"
+              },
+              "meta": {
+                "$ref": "#/components/schemas/meta"
+              }
+            }
+          }
+        ]
+      },
+      "links": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/link"
+        }
+      },
+      "reltoone": {
+        "description": "a singular 'to-one' relationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "$ref": "#/components/schemas/relationshipLinks"
+          },
+          "data": {
+            "$ref": "#/components/schemas/relationshipToOne"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        }
+      },
+      "relationshipToOne": {
+        "description": "reference to other resource in a to-one relationship",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/nulltype"
+          },
+          {
+            "$ref": "#/components/schemas/linkage"
+          }
+        ]
+      },
+      "reltomany": {
+        "description": "a multiple 'to-many' relationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "$ref": "#/components/schemas/relationshipLinks"
+          },
+          "data": {
+            "$ref": "#/components/schemas/relationshipToMany"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        }
+      },
+      "relationshipLinks": {
+        "description": "optional references to other resource objects",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "self": {
+            "$ref": "#/components/schemas/link"
+          },
+          "related": {
+            "$ref": "#/components/schemas/link"
+          }
+        }
+      },
+      "relationshipToMany": {
+        "description": "An array of objects each containing the 'type' and 'id' for to-many relationships",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/linkage"
+        },
+        "uniqueItems": true
+      },
+      "ResourceIdentifierObject": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/relationshipToOne"
+          },
+          {
+            "$ref": "#/components/schemas/relationshipToMany"
+          }
+        ]
+      },
+      "linkage": {
+        "type": "object",
+        "description": "the 'type' and 'id'",
+        "required": [
+          "type",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        }
+      },
+      "pagination": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "$ref": "#/components/schemas/pageref"
+          },
+          "last": {
+            "$ref": "#/components/schemas/pageref"
+          },
+          "prev": {
+            "$ref": "#/components/schemas/pageref"
+          },
+          "next": {
+            "$ref": "#/components/schemas/pageref"
+          }
+        }
+      },
+      "pageref": {
+        "oneOf": [
+          {
+            "type": "string",
+            "format": "uri-reference"
+          },
+          {
+            "$ref": "#/components/schemas/nulltype"
+          }
+        ]
+      },
+      "failure": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "$ref": "#/components/schemas/errors"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/jsonapi"
+          },
+          "links": {
+            "$ref": "#/components/schemas/links"
+          }
+        }
+      },
+      "errors": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/error"
+        },
+        "uniqueItems": true
+      },
+      "error": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "links": {
+            "$ref": "#/components/schemas/links"
+          },
+          "code": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "pointer": {
+                "type": "string",
+                "description": "A [JSON Pointer](https://tools.ietf.org/html/rfc6901) to the associated entity in the request document [e.g. `/data` for a primary data object, or `/data/attributes/title` for a specific attribute."
+              },
+              "parameter": {
+                "type": "string",
+                "description": "A string indicating which query parameter caused the error."
+              },
+              "meta": {
+                "$ref": "#/components/schemas/meta"
+              }
+            }
+          }
+        }
+      },
+      "onlymeta": {
+        "additionalProperties": false,
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        }
+      },
+      "meta": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "datum": {
+        "description": "singular item",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/resource"
+          }
+        }
+      },
+      "nulltype": {
+        "type": "object",
+        "nullable": true,
+        "default": null
+      },
+      "type": {
+        "type": "string",
+        "description": "The [type](https://jsonapi.org/format/#document-resource-object-identification) member is used to describe resource objects that share common attributes and relationships."
+      },
+      "id": {
+        "type": "string",
+        "description": "Each resource object’s type and id pair MUST [identify](https://jsonapi.org/format/#document-resource-object-identification) a single, unique resource."
+      },
+      "WebMapService": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "created_at": {
+                "type": "string",
+                "readOnly": true
+              },
+              "last_modified_at": {
+                "type": "string",
+                "readOnly": true
+              },
+              "is_accessible": {
+                "type": "string",
+                "readOnly": true
+              },
+              "xml_backup_file": {
+                "type": "string",
+                "format": "binary",
+                "readOnly": true,
+                "description": "the original xml as backup to restore the xml field."
+              },
+              "access_constraints": {
+                "type": "string",
+                "nullable": true,
+                "description": "access constraints for the given resource."
+              },
+              "fees": {
+                "type": "string",
+                "nullable": true,
+                "description": "Costs and of terms of use for the given resource."
+              },
+              "use_limitation": {
+                "type": "string",
+                "nullable": true
+              },
+              "license_source_note": {
+                "type": "string",
+                "nullable": true
+              },
+              "date_stamp": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true,
+                "description": "date that the metadata was created. If this is a metadata record which is parsed from remote iso metadata, the date stamp of the remote iso metadata will be used."
+              },
+              "file_identifier": {
+                "type": "string",
+                "readOnly": true,
+                "description": "the parsed file identifier from the iso metadata xml (gmd:fileIdentifier) OR for example if it is a layer/featuretypethe uuid of the described layer/featuretype shall be used to identify the generated iso metadata xml."
+              },
+              "origin": {
+                "type": "string",
+                "readOnly": true,
+                "description": "Where the metadata record comes from."
+              },
+              "origin_url": {
+                "type": "string",
+                "format": "uri",
+                "readOnly": true,
+                "description": "the url of the document where the information of this metadata record comes from",
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "title": {
+                "type": "string",
+                "description": "a short descriptive title for this metadata",
+                "maxLength": 1000
+              },
+              "abstract": {
+                "type": "string",
+                "nullable": true,
+                "description": "brief summary of the content of this metadata."
+              },
+              "is_broken": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "TODO"
+              },
+              "is_customized": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "If the metadata record is customized, this flag is True"
+              },
+              "insufficient_quality": {
+                "type": "string",
+                "nullable": true,
+                "description": "TODO"
+              },
+              "is_searchable": {
+                "type": "boolean",
+                "description": "only searchable metadata will be returned from the search api"
+              },
+              "hits": {
+                "type": "integer",
+                "readOnly": true,
+                "description": "how many times this metadata was requested by a client"
+              },
+              "is_active": {
+                "type": "boolean",
+                "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+              },
+              "version": {
+                "type": "string",
+                "readOnly": true,
+                "description": "the version of the service type as sem version"
+              },
+              "service_url": {
+                "type": "string",
+                "format": "uri",
+                "readOnly": true,
+                "description": "the base url of the service",
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "get_capabilities_url": {
+                "type": "string",
+                "format": "uri",
+                "description": "the capabilities url of the ogc service",
+                "maxLength": 4096,
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              }
+            },
+            "required": [
+              "title",
+              "get_capabilities_url"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "layers": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "service_contact": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "metadata_contact": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "keywords": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "created_by": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "last_modified_by": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "licence": {
+                "$ref": "#/components/schemas/reltoone"
+              }
+            }
+          }
+        }
+      },
+      "Layer": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "readOnly": true
+              },
+              "bbox_lat_lon": {
+                "type": "string"
+              },
+              "xml_backup_file": {
+                "type": "string",
+                "format": "binary",
+                "readOnly": true,
+                "description": "the original xml as backup to restore the xml field."
+              },
+              "date_stamp": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true,
+                "description": "date that the metadata was created. If this is a metadata record which is parsed from remote iso metadata, the date stamp of the remote iso metadata will be used."
+              },
+              "file_identifier": {
+                "type": "string",
+                "readOnly": true,
+                "description": "the parsed file identifier from the iso metadata xml (gmd:fileIdentifier) OR for example if it is a layer/featuretypethe uuid of the described layer/featuretype shall be used to identify the generated iso metadata xml."
+              },
+              "origin": {
+                "type": "string",
+                "readOnly": true,
+                "description": "Where the metadata record comes from."
+              },
+              "origin_url": {
+                "type": "string",
+                "format": "uri",
+                "readOnly": true,
+                "description": "the url of the document where the information of this metadata record comes from",
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "title": {
+                "type": "string",
+                "description": "a short descriptive title for this metadata",
+                "maxLength": 1000
+              },
+              "abstract": {
+                "type": "string",
+                "nullable": true,
+                "description": "brief summary of the content of this metadata."
+              },
+              "is_broken": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "TODO"
+              },
+              "is_customized": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "If the metadata record is customized, this flag is True"
+              },
+              "insufficient_quality": {
+                "type": "string",
+                "nullable": true,
+                "description": "TODO"
+              },
+              "is_searchable": {
+                "type": "boolean",
+                "description": "only searchable metadata will be returned from the search api"
+              },
+              "hits": {
+                "type": "integer",
+                "readOnly": true,
+                "description": "how many times this metadata was requested by a client"
+              },
+              "preview_image": {
+                "type": "string",
+                "format": "binary",
+                "nullable": true
+              },
+              "is_active": {
+                "type": "boolean",
+                "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+              },
+              "identifier": {
+                "type": "string",
+                "readOnly": true,
+                "description": "this is a string which identifies the element on the remote service."
+              },
+              "is_queryable": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "flag to signal if this layer provides factual information or not. Parsed from capabilities."
+              },
+              "is_opaque": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "flag to signal if this layer support transparency content or not. Parsed from capabilities."
+              },
+              "is_cascaded": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "WMS cascading allows to expose layers coming from other WMS servers as if they were local layers"
+              },
+              "scale_min": {
+                "type": "number",
+                "readOnly": true,
+                "description": "minimum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+              },
+              "scale_max": {
+                "type": "number",
+                "readOnly": true,
+                "description": "maximum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+              },
+              "lft": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "rght": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "tree_id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "level": {
+                "type": "integer",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "bbox_lat_lon",
+              "title"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "styles": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "keywords": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "service": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "parent": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "reference_systems": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "MetadataContact": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the organization",
+                "maxLength": 256
+              },
+              "person_name": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "maxLength": 100
+              },
+              "phone": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "facsimile": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "city": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "postal_code": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "address_type": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "address": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "state_or_province": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "country": {
+                "type": "string",
+                "maxLength": 100
+              }
+            }
+          }
+        }
+      },
+      "Keyword": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "keyword": {
+                "type": "string",
+                "maxLength": 255
+              }
+            },
+            "required": [
+              "keyword"
+            ]
+          }
+        }
+      },
+      "Style": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "name": {
+                "type": "string",
+                "readOnly": true,
+                "description": "The style's Name is used in the Map request STYLES parameter to lookup the style on server side."
+              },
+              "title": {
+                "type": "string",
+                "readOnly": true,
+                "description": "The Title is a human-readable string as an alternative for the name attribute."
+              }
+            }
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "layer": {
+                "$ref": "#/components/schemas/reltoone"
+              }
+            }
+          }
+        }
+      },
+      "WebFeatureService": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "readOnly": true
+              },
+              "xml_backup_file": {
+                "type": "string",
+                "format": "binary",
+                "readOnly": true,
+                "description": "the original xml as backup to restore the xml field."
+              },
+              "access_constraints": {
+                "type": "string",
+                "nullable": true,
+                "description": "access constraints for the given resource."
+              },
+              "fees": {
+                "type": "string",
+                "nullable": true,
+                "description": "Costs and of terms of use for the given resource."
+              },
+              "use_limitation": {
+                "type": "string",
+                "nullable": true
+              },
+              "license_source_note": {
+                "type": "string",
+                "nullable": true
+              },
+              "date_stamp": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true,
+                "description": "date that the metadata was created. If this is a metadata record which is parsed from remote iso metadata, the date stamp of the remote iso metadata will be used."
+              },
+              "file_identifier": {
+                "type": "string",
+                "readOnly": true,
+                "description": "the parsed file identifier from the iso metadata xml (gmd:fileIdentifier) OR for example if it is a layer/featuretypethe uuid of the described layer/featuretype shall be used to identify the generated iso metadata xml."
+              },
+              "origin": {
+                "type": "string",
+                "readOnly": true,
+                "description": "Where the metadata record comes from."
+              },
+              "origin_url": {
+                "type": "string",
+                "format": "uri",
+                "readOnly": true,
+                "description": "the url of the document where the information of this metadata record comes from",
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "title": {
+                "type": "string",
+                "description": "a short descriptive title for this metadata",
+                "maxLength": 1000
+              },
+              "abstract": {
+                "type": "string",
+                "nullable": true,
+                "description": "brief summary of the content of this metadata."
+              },
+              "is_broken": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "TODO"
+              },
+              "is_customized": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "If the metadata record is customized, this flag is True"
+              },
+              "insufficient_quality": {
+                "type": "string",
+                "nullable": true,
+                "description": "TODO"
+              },
+              "is_searchable": {
+                "type": "boolean",
+                "description": "only searchable metadata will be returned from the search api"
+              },
+              "hits": {
+                "type": "integer",
+                "readOnly": true,
+                "description": "how many times this metadata was requested by a client"
+              },
+              "is_active": {
+                "type": "boolean",
+                "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+              },
+              "version": {
+                "type": "string",
+                "readOnly": true,
+                "description": "the version of the service type as sem version"
+              },
+              "service_url": {
+                "type": "string",
+                "format": "uri",
+                "readOnly": true,
+                "description": "the base url of the service",
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "get_capabilities_url": {
+                "type": "string",
+                "format": "uri",
+                "description": "the capabilities url of the ogc service",
+                "maxLength": 4096,
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              }
+            },
+            "required": [
+              "title",
+              "get_capabilities_url"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "featuretypes": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "licence": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "service_contact": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "metadata_contact": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "keywords": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "FeatureType": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "readOnly": true
+              },
+              "xml_backup_file": {
+                "type": "string",
+                "format": "binary",
+                "readOnly": true,
+                "description": "the original xml as backup to restore the xml field."
+              },
+              "date_stamp": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true,
+                "description": "date that the metadata was created. If this is a metadata record which is parsed from remote iso metadata, the date stamp of the remote iso metadata will be used."
+              },
+              "file_identifier": {
+                "type": "string",
+                "readOnly": true,
+                "description": "the parsed file identifier from the iso metadata xml (gmd:fileIdentifier) OR for example if it is a layer/featuretypethe uuid of the described layer/featuretype shall be used to identify the generated iso metadata xml."
+              },
+              "origin": {
+                "type": "string",
+                "readOnly": true,
+                "description": "Where the metadata record comes from."
+              },
+              "origin_url": {
+                "type": "string",
+                "format": "uri",
+                "readOnly": true,
+                "description": "the url of the document where the information of this metadata record comes from",
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "title": {
+                "type": "string",
+                "description": "a short descriptive title for this metadata",
+                "maxLength": 1000
+              },
+              "abstract": {
+                "type": "string",
+                "nullable": true,
+                "description": "brief summary of the content of this metadata."
+              },
+              "is_broken": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "TODO"
+              },
+              "is_customized": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "If the metadata record is customized, this flag is True"
+              },
+              "insufficient_quality": {
+                "type": "string",
+                "nullable": true,
+                "description": "TODO"
+              },
+              "is_searchable": {
+                "type": "boolean",
+                "description": "only searchable metadata will be returned from the search api"
+              },
+              "hits": {
+                "type": "integer",
+                "readOnly": true,
+                "description": "how many times this metadata was requested by a client"
+              },
+              "is_active": {
+                "type": "boolean",
+                "description": "Used to activate/deactivate the service. If it is deactivated, you cant request the service through the Mr. Map proxy."
+              },
+              "identifier": {
+                "type": "string",
+                "readOnly": true,
+                "description": "this is a string which identifies the element on the remote service."
+              },
+              "bbox_lat_lon": {
+                "type": "string",
+                "readOnly": true,
+                "description": "bounding box shall be supplied regardless of what CRS the map server may support, but it may be approximate if the data are not natively in geographic coordinates. The purpose of bounding box is to facilitate geographic searches without requiring coordinate transformations by the search engine."
+              },
+              "describe_feature_type_document": {
+                "type": "string",
+                "nullable": true,
+                "description": "the fetched content of the download describe feature type document."
+              }
+            },
+            "required": [
+              "title"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "keywords": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "service": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "reference_systems": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "output_formats": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "MapContextDefault": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "title": {
+                "type": "string",
+                "description": "a short descriptive title for this map context",
+                "maxLength": 1000
+              },
+              "abstract": {
+                "type": "string",
+                "nullable": true,
+                "description": "brief summary of the topic of this map context"
+              }
+            },
+            "required": [
+              "title"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "map_context_layers": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "MapContextLayer": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "name": {
+                "type": "string",
+                "description": "an identifying name for this map context layer",
+                "maxLength": 1000
+              },
+              "title": {
+                "type": "string",
+                "nullable": true,
+                "description": "a short descriptive title for this map context layer",
+                "maxLength": 1000
+              },
+              "layer_scale_min": {
+                "type": "number",
+                "nullable": true,
+                "description": "minimum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+              },
+              "layer_scale_max": {
+                "type": "number",
+                "nullable": true,
+                "description": "maximum scale for a possible request to this layer. If the request is out of the given scope, the service will response with empty transparentimages. None value means no restriction."
+              },
+              "preview_image": {
+                "type": "string",
+                "format": "binary",
+                "nullable": true,
+                "description": "A preview image for the Map Context Layer"
+              },
+              "lft": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "rght": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "tree_id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "level": {
+                "type": "integer",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "parent": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "map_context": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "dataset_metadata": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "rendering_layer": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "layer_style": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "selection_layer": {
+                "$ref": "#/components/schemas/reltoone"
+              }
+            }
+          }
+        }
+      },
+      "DatasetMetadata": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "readOnly": true
+              },
+              "xml_backup_file": {
+                "type": "string",
+                "format": "binary",
+                "readOnly": true,
+                "description": "the original xml as backup to restore the xml field."
+              },
+              "access_constraints": {
+                "type": "string",
+                "nullable": true,
+                "description": "access constraints for the given resource."
+              },
+              "fees": {
+                "type": "string",
+                "nullable": true,
+                "description": "Costs and of terms of use for the given resource."
+              },
+              "use_limitation": {
+                "type": "string",
+                "nullable": true
+              },
+              "license_source_note": {
+                "type": "string",
+                "nullable": true
+              },
+              "date_stamp": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true,
+                "description": "date that the metadata was created. If this is a metadata record which is parsed from remote iso metadata, the date stamp of the remote iso metadata will be used."
+              },
+              "file_identifier": {
+                "type": "string",
+                "readOnly": true,
+                "description": "the parsed file identifier from the iso metadata xml (gmd:fileIdentifier) OR for example if it is a layer/featuretypethe uuid of the described layer/featuretype shall be used to identify the generated iso metadata xml."
+              },
+              "origin": {
+                "type": "string",
+                "readOnly": true,
+                "description": "Where the metadata record comes from."
+              },
+              "origin_url": {
+                "type": "string",
+                "format": "uri",
+                "readOnly": true,
+                "description": "the url of the document where the information of this metadata record comes from",
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "title": {
+                "type": "string",
+                "description": "a short descriptive title for this metadata",
+                "maxLength": 1000
+              },
+              "abstract": {
+                "type": "string",
+                "nullable": true,
+                "description": "brief summary of the content of this metadata."
+              },
+              "is_broken": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "TODO"
+              },
+              "is_customized": {
+                "type": "boolean",
+                "readOnly": true,
+                "description": "If the metadata record is customized, this flag is True"
+              },
+              "insufficient_quality": {
+                "type": "string",
+                "nullable": true,
+                "description": "TODO"
+              },
+              "is_searchable": {
+                "type": "boolean",
+                "description": "only searchable metadata will be returned from the search api"
+              },
+              "hits": {
+                "type": "integer",
+                "readOnly": true,
+                "description": "how many times this metadata was requested by a client"
+              },
+              "spatial_res_type": {
+                "enum": [
+                  "groundDistance",
+                  "scaleDenominator"
+                ],
+                "type": "string",
+                "nullable": true,
+                "description": "Ground resolution in meter or the equivalent scale."
+              },
+              "spatial_res_value": {
+                "type": "number",
+                "nullable": true,
+                "description": "The value depending on the selected resolution type."
+              },
+              "format": {
+                "enum": [
+                  null,
+                  "Database",
+                  "Esri shape",
+                  "CSV",
+                  "GML",
+                  "GeoTIFF"
+                ],
+                "nullable": true,
+                "description": "The format in which the described dataset is stored."
+              },
+              "charset": {
+                "enum": [
+                  null,
+                  "utf8"
+                ],
+                "nullable": true,
+                "description": "The charset which is used by the stored data."
+              },
+              "inspire_top_consistence": {
+                "type": "boolean",
+                "description": "Flag to signal if the described data has a topologically consistence."
+              },
+              "preview_image": {
+                "type": "string",
+                "format": "binary",
+                "nullable": true
+              },
+              "lineage_statement": {
+                "type": "string",
+                "nullable": true
+              },
+              "update_frequency_code": {
+                "enum": [
+                  "annually",
+                  "asNeeded",
+                  "biannually",
+                  "irregular",
+                  "notPlanned",
+                  "unknown"
+                ],
+                "type": "string",
+                "nullable": true
+              },
+              "bounding_geometry": {
+                "type": "string",
+                "nullable": true
+              },
+              "dataset_id": {
+                "type": "string",
+                "nullable": true,
+                "description": "identifier of the remote data",
+                "maxLength": 4096
+              },
+              "dataset_id_code_space": {
+                "type": "string",
+                "description": "code space for the given identifier",
+                "maxLength": 4096
+              },
+              "inspire_interoperability": {
+                "type": "boolean",
+                "description": "flag to signal if this "
+              }
+            },
+            "required": [
+              "title"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "licence": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "dataset_contact": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "metadata_contact": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "keywords": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "reference_systems": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "self_pointing_layers": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "self_pointing_feature_types": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "self_pointing_catalouge_service": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "readOnly": true
+              },
+              "last_login": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "is_superuser": {
+                "type": "boolean",
+                "description": "Designates that this user has all permissions without explicitly assigning them."
+              },
+              "username": {
+                "type": "string",
+                "description": "Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+                "pattern": "^[\\w.@+-]+\\z",
+                "maxLength": 150
+              },
+              "first_name": {
+                "type": "string",
+                "maxLength": 150
+              },
+              "last_name": {
+                "type": "string",
+                "maxLength": 150
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "maxLength": 254
+              },
+              "is_staff": {
+                "type": "boolean",
+                "description": "Designates whether the user can log into this admin site."
+              },
+              "is_active": {
+                "type": "boolean",
+                "description": "Designates whether this user should be treated as active. Unselect this instead of deleting accounts."
+              },
+              "date_joined": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "confirmed_newsletter": {
+                "type": "boolean"
+              },
+              "confirmed_survey": {
+                "type": "boolean"
+              },
+              "confirmed_dsgvo": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true,
+                "description": "I understand and accept that my data will be automatically processed and securely stored, as it is stated in the general data protection regulation (GDPR)."
+              }
+            },
+            "required": [
+              "username"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "groups": {
+                "$ref": "#/components/schemas/reltomany"
+              },
+              "user_permissions": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "Group": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "name": {
+                "type": "string",
+                "maxLength": 150
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "permissions": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "Organization": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "name": {
+                "type": "string",
+                "maxLength": 150
+              },
+              "person_name": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 200
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "phone": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "facsimile": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "city": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "postal_code": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "address_type": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "address": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "state_or_province": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "country": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 100
+              },
+              "description": {
+                "type": "string",
+                "nullable": true,
+                "description": "Describe what this organization representing"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "permissions": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "Permission": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "name": {
+                "type": "string",
+                "maxLength": 255
+              },
+              "codename": {
+                "type": "string",
+                "maxLength": 100
+              }
+            },
+            "required": [
+              "name",
+              "codename"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "content_type": {
+                "$ref": "#/components/schemas/reltoone"
+              }
+            }
+          }
+        }
+      },
+      "TaskResult": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "task_meta": {
+                "type": "string",
+                "readOnly": true
+              },
+              "result": {
+                "type": "string",
+                "readOnly": true
+              },
+              "task_id": {
+                "type": "string",
+                "description": "Celery ID for the Task that was run",
+                "maxLength": 255
+              },
+              "task_name": {
+                "type": "string",
+                "nullable": true,
+                "description": "Name of the Task which was run",
+                "maxLength": 255
+              },
+              "task_args": {
+                "type": "string",
+                "nullable": true,
+                "description": "JSON representation of the positional arguments used with the task"
+              },
+              "task_kwargs": {
+                "type": "string",
+                "nullable": true,
+                "description": "JSON representation of the named arguments used with the task"
+              },
+              "status": {
+                "enum": [
+                  "FAILURE",
+                  "PENDING",
+                  "RECEIVED",
+                  "RETRY",
+                  "REVOKED",
+                  "STARTED",
+                  "SUCCESS"
+                ],
+                "type": "string",
+                "description": "Current state of the task being run"
+              },
+              "worker": {
+                "type": "string",
+                "nullable": true,
+                "description": "Worker that executes the task",
+                "maxLength": 100
+              },
+              "content_type": {
+                "type": "string",
+                "description": "Content type of the result data",
+                "maxLength": 128
+              },
+              "content_encoding": {
+                "type": "string",
+                "description": "The encoding used to save the task result data",
+                "maxLength": 64
+              },
+              "date_created": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true,
+                "description": "Datetime field when the task result was created in UTC"
+              },
+              "date_done": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true,
+                "description": "Datetime field when the task was completed in UTC"
+              },
+              "traceback": {
+                "type": "string",
+                "nullable": true,
+                "description": "Text of the traceback if the task generated one"
+              }
+            },
+            "required": [
+              "task_id",
+              "content_type",
+              "content_encoding"
+            ]
+          }
+        }
+      },
+      "WebMapServiceCreate": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "get_capabilities_url": {
+                "type": "string",
+                "format": "uri",
+                "description": "the capabilities url of the ogc service",
+                "maxLength": 4096,
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "collect_metadata_records": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "get_capabilities_url"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "owner": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "service_auth": {
+                "$ref": "#/components/schemas/reltoone"
+              }
+            }
+          }
+        }
+      },
+      "WebFeatureServiceCreate": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "get_capabilities_url": {
+                "type": "string",
+                "format": "uri",
+                "description": "the capabilities url of the ogc service",
+                "maxLength": 4096,
+                "pattern": "^(?:[a-z0-9.+-]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)(?:\\.(?:0|25[0-5]|2[0-4]\\d|1\\d?\\d?|[1-9]\\d?)){3}|\\[[0-9a-f:.]+\\]|([a-z¡-\uffff0-9](?:[a-z¡-\uffff0-9-]{0,61}[a-z¡-\uffff0-9])?(?:\\.(?!-)[a-z¡-\uffff0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z¡-\uffff-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\z"
+              },
+              "collect_metadata_records": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "get_capabilities_url"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "owner": {
+                "$ref": "#/components/schemas/reltoone"
+              },
+              "service_auth": {
+                "$ref": "#/components/schemas/reltoone"
+              }
+            }
+          }
+        }
+      },
+      "MapContextLayerMoveLayer": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "integer"
+              },
+              "position": {
+                "enum": [
+                  "first-child",
+                  "last-child",
+                  "left",
+                  "right"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "target",
+              "position"
+            ]
+          }
+        }
+      },
+      "UserCreate": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "username": {
+                "type": "string",
+                "description": "Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+                "pattern": "^[\\w.@+-]+\\z",
+                "maxLength": 150
+              },
+              "password": {
+                "type": "string",
+                "maxLength": 128
+              }
+            },
+            "required": [
+              "username",
+              "password"
+            ]
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "groups": {
+                "$ref": "#/components/schemas/reltomany"
+              }
+            }
+          }
+        }
+      },
+      "Login": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "username": {
+                "type": "string"
+              },
+              "password": {
+                "type": "string",
+                "writeOnly": true
+              }
+            },
+            "required": [
+              "username",
+              "password"
+            ]
+          }
+        }
+      },
+      "Logout": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/type"
+          },
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/link"
+              }
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "include": {
+        "name": "include",
+        "in": "query",
+        "description": "[list of included related resources](https://jsonapi.org/format/#fetching-includes)",
+        "required": false,
+        "style": "form",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "fields": {
+        "name": "fields",
+        "in": "query",
+        "description": "[sparse fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets).\nUse fields[\\<typename\\>]=field1,field2,...,fieldN",
+        "required": false,
+        "style": "deepObject",
+        "schema": {
+          "type": "object"
+        },
+        "explode": true
+      },
+      "sort": {
+        "name": "sort",
+        "in": "query",
+        "description": "[list of fields to sort by](https://jsonapi.org/format/#fetching-sorting)",
+        "required": false,
+        "style": "form",
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This implements #322.

Changes:

- Added `SearchDrawer` component.
- Added passing of `ProTable` props from `RepoTable` component.
- Added `node_modules` to `.dockerignore` to speedup Docker build.
- Added VSCode launch configuration for debugging frontend tests.
- Added typing for `OgcServiceAddProps`.
- Added test for `SearchDrawer` component. This includes mocking of the repo layer. There's still a to do left however, currently we get a warning caused by a re-rendering caused by the the `RepoTable`.
