### PR TITLE
WMS Security Proxy: Implement basic component with layer tree

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,16 +15,16 @@ import FeatureTypeTable from './Components/OgcService/FeatureTypeTable';
 import LayerTable from './Components/OgcService/LayerTable';
 import OgcServiceAdd from './Components/OgcService/OgcServiceAdd';
 import WfsTable from './Components/OgcService/WfsTable';
-import WmsTable from './Components/OgcService/WmsTable';
 import { PageNotFound } from './Components/PageNotFound/PageNotFound';
 import { TaskProgressList } from './Components/Task/TaskProgress';
 import { Login } from './Components/Users/Auth/Login';
 import { Logout } from './Components/Users/Auth/Logout';
+import { WmsSecuritySettings } from './Components/WmsSecuritySettings/WmsSecuritySettings';
+import WmsTable from './Components/WmsTable/WmsTable';
 import { AuthProvider, useAuth } from './Hooks/AuthContextProvider';
 import logo from './logo.png';
 import WebFeatureServiceRepo from './Repos/WfsRepo';
 import WebMapServiceRepo from './Repos/WmsRepo';
-
 
 
 const { Content, Footer, Sider } = Layout;
@@ -112,9 +112,13 @@ export default function App (): JSX.Element {
                 path='/registry/services/wms'
                 element={<WmsTable />}
               />
-               <Route
+              <Route
                 path='/registry/services/wms/add'
                 element={<OgcServiceAdd repo={new WebMapServiceRepo()} />}
+              />
+              <Route
+                path='/registry/services/wms/:id/security'
+                element={<WmsSecuritySettings />}
               />
               <Route
                 path='/registry/services/wfs'

--- a/frontend/src/Components/MapContextForm/MapContext.tsx
+++ b/frontend/src/Components/MapContextForm/MapContext.tsx
@@ -56,8 +56,8 @@ export const MapContext = (): ReactElement => {
             // @ts-ignore
             abstract: response.mapContext.attributes.abstract || ''
           });
-          //  Convert the mapContext layers coming from the server to a compatible tree node list
-          const _initLayerTreeData = treeUtils.MPTTListToOLLayerGroup(response.mapContextLayers);
+          // Convert the mapContext layers coming from the server to a compatible tree node list
+          const _initLayerTreeData = treeUtils.mapContextLayersToOlLayerGroup(response.mapContextLayers);
           setInitLayerTreeData(_initLayerTreeData);
         } catch (error) {
           // @ts-ignore
@@ -71,13 +71,13 @@ export const MapContext = (): ReactElement => {
       setIsMapContextSearchDrawerVisible(true);
     }
   }, [id, form]);
-  
+
 
   const onAddDatasetToMapAction = async(dataset:any) => {
     dataset.layers.forEach(async (layer: string) => {
       const getParentId = (): string => {
         const currentSelectedIsNodeOnRoot = currentSelectedTreeLayerNode &&
-          !currentSelectedTreeLayerNode?.parent && 
+          !currentSelectedTreeLayerNode?.parent &&
           !currentSelectedTreeLayerNode?.isLeaf;
         const currentSelectedIsLeafOnRoot = currentSelectedTreeLayerNode &&
           !currentSelectedTreeLayerNode?.parent &&
@@ -87,7 +87,7 @@ export const MapContext = (): ReactElement => {
           !currentSelectedTreeLayerNode?.isLeaf;
         const currentSelectedIsLeafWithParent = currentSelectedTreeLayerNode && currentSelectedTreeLayerNode?.parent &&
           currentSelectedTreeLayerNode?.isLeaf;
-        
+
         if(currentSelectedIsNodeOnRoot) {
           return String(currentSelectedTreeLayerNode?.key);
         }
@@ -168,17 +168,17 @@ export const MapContext = (): ReactElement => {
         if(res.attributes.WMSParams.bbox) {
           olMap.getView().fit(transformExtent(res.attributes.WMSParams.bbox, 'EPSG:4326', 'EPSG:3857'));
         }
-        
+
         const mapContextLayersGroup = layerUtils.getLayerGroupByGroupTitle(olMap, 'mrMapMapContextLayers');
-        
+
         if(mapContextLayersGroup) {
           layerUtils.addLayerToGroupByMrMapLayerId(
-            mapContextLayersGroup, 
-            currentSelectedTreeLayerNode?.key as string, 
+            mapContextLayersGroup,
+            currentSelectedTreeLayerNode?.key as string,
             renderingLayer
           );
         }
-        
+
         notification.info({
           message: `Add dataset '${dataset.title}'`
         });
@@ -198,7 +198,7 @@ export const MapContext = (): ReactElement => {
       }
     });
   };
-  
+
   // TODO: replace for a decent loading screen
   if(isLoadingMapContextInfo) {
     return (<SyncOutlined spin />);
@@ -208,7 +208,7 @@ export const MapContext = (): ReactElement => {
     <>
       <div className='map-context'>
         <ReactGeoMapContext.Provider value={olMap}>
-          <TheMap 
+          <TheMap
             selectLayerDispatchAction={(selectedKeys, info) => setCurrentSelectedTreeLayerNode(info.node)}
             addLayerDispatchAction={async (nodeAttributes, newNodeParent) => {
               let renderingLayerInfo = null;
@@ -255,7 +255,7 @@ export const MapContext = (): ReactElement => {
               } catch (error) {
                 //@ts-ignore
                 throw new Error(error);
-              }      
+              }
             }}
             removeLayerDispatchAction={async (nodeToRemove) => {
               try {
@@ -291,7 +291,7 @@ export const MapContext = (): ReactElement => {
                   message: 'No MapContext was created. Please create a valid Map '+
                     'Context before adding Map Context Layers'
                 });
-                
+
               } else {
                 notification.error({
                   message: 'Something went wrong while trying to create the layer'
@@ -317,15 +317,15 @@ export const MapContext = (): ReactElement => {
                   {nodeData.properties.datasetMetadata && (
                     <FontAwesomeIcon icon={['fas','eye']} />
                   )}
-                  <FontAwesomeIcon 
-                    icon={['fas',`${nodeData.properties.renderingLayer ? 'eye' : 'eye-slash'}`]} 
+                  <FontAwesomeIcon
+                    icon={['fas',`${nodeData.properties.renderingLayer ? 'eye' : 'eye-slash'}`]}
                   />
-                  <FontAwesomeIcon 
-                    icon={[`${nodeData.properties.featureSelectionLayer ? 'fas' : 'far'}`,'check-circle']} 
+                  <FontAwesomeIcon
+                    icon={[`${nodeData.properties.featureSelectionLayer ? 'fas' : 'far'}`,'check-circle']}
                   />
-                  </>
-            );
-          }}
+                </>
+              );
+            }}
           />
         </ReactGeoMapContext.Provider>
       </div>

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer.css
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer.css
@@ -1,0 +1,20 @@
+.rules-drawer-toggle-button {
+  position: absolute;
+  top: 50%;
+  z-index: 1001;
+  height: 60px;
+  width: 30px;
+  padding: 0;
+  border-radius: 5px 0 0 5px;
+  border: none;
+  /* same transition timing as drawer */
+  transition: right 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.rules-drawer-toggle-button.collapsed {
+  right: 0px;
+}
+
+.rules-drawer-toggle-button.expanded {
+  right: 500px;
+}

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer.tsx
@@ -1,0 +1,38 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button, Drawer } from 'antd';
+import React, { useRef, useState } from 'react';
+import './RulesDrawer.css';
+
+export const RulesDrawer: React.FC = () => {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [isVisible, setIsVisible] = useState<boolean>(true);
+    const toggleVisible = () => {
+      setIsVisible(!isVisible);
+      buttonRef.current?.blur();
+    };
+    return (
+      <>
+        <Button
+          ref={buttonRef}
+          className={`rules-drawer-toggle-button ${isVisible ? 'expanded' : 'collapsed'}`}
+          onClick={toggleVisible}
+          icon={(
+            <FontAwesomeIcon
+              icon={['fas', isVisible ? 'angle-double-right' : 'angle-double-left']}
+            />
+          )}
+        />
+        <Drawer
+          placement='right'
+          width={500}
+          visible={isVisible}
+          closable={false}
+          mask={false}
+        >
+          Rules
+        </Drawer>
+      </>
+    );
+};
+
+export default RulesDrawer;

--- a/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.css
+++ b/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.css
@@ -1,0 +1,11 @@
+.map-context {
+  width: calc(
+    100% + 48px
+  ); /* to overlap parent's padding defined in site-layout class */
+  height: calc(
+    100% + 48px
+  ); /* to overlap parent's padding defined in site-layout class */
+  position: relative;
+  margin-left: -24px; /* to overlap parent's padding defined in site-layout class */
+  margin-top: -24px; /* to overlap parent's padding defined in site-layout class */
+}

--- a/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.tsx
@@ -1,0 +1,83 @@
+import { SyncOutlined } from '@ant-design/icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { MapContext as ReactGeoMapContext } from '@terrestris/react-geo';
+import Collection from 'ol/Collection';
+import React, { ReactElement, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import WmsRepo from '../../Repos/WmsRepo';
+import { TreeUtils } from '../../Utils/TreeUtils';
+import { TreeNodeType } from '../Shared/FormFields/TreeFormField/TreeFormFieldTypes';
+import { olMap, TheMap } from '../TheMap/TheMap';
+import { RulesDrawer } from './RulesDrawer';
+import './WmsSecuritySettings.css';
+
+const wmsRepo = new WmsRepo();
+const treeUtils = new TreeUtils();
+
+export const WmsSecuritySettings = (): ReactElement => {
+
+  // get the ID parameter from the url
+  const { id } = useParams();
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [initLayerTreeData, setInitLayerTreeData] = useState<Collection<any>>(new Collection());
+
+  useEffect(() => {
+    // TODO: need to add some sort of loading until the values are fetched
+    // olMap.addLayer(mapContextLayersPreviewGroup);
+    if (id) {
+      setIsLoading(true);
+      const fetchMapContext = async () => {
+        try {
+          // const response = await mapContextRepo.getMapContextWithLayers(String(id));
+          const response = await wmsRepo.getAllLayers(String(id));
+          // Convert the mapContext layers coming from the server to a compatible tree node list
+          const _initLayerTreeData = treeUtils.wmsLayersToOlLayerGroup((response as any).data?.data);
+          setInitLayerTreeData(_initLayerTreeData);
+        } catch (error) {
+          // @ts-ignore
+          throw new Error(error);
+        } finally {
+          setIsLoading(false);
+        }
+      };
+      fetchMapContext();
+    }
+  }, [id]);
+
+  // TODO: replace for a decent loading screen
+  if(isLoading) {
+    return (<SyncOutlined spin />);
+  }
+
+  return (
+    <>
+      <div className='map-context'>
+        <ReactGeoMapContext.Provider value={olMap}>
+          <TheMap
+            selectLayerDispatchAction={(selectedKeys, info) => console.log("selected", info.node)}
+            layerGroupName='mrMapWmsSecurityLayers'
+            initLayerTreeData={initLayerTreeData}
+            layerAttributeForm={(<h1>Placeholder</h1>)}
+            layerAttributeInfoIcons={(nodeData:TreeNodeType) => {
+              if(!nodeData.isLeaf) {
+                return (<></>);
+              }
+              return (
+                <>
+                  {nodeData.properties.datasetMetadata && (
+                    <FontAwesomeIcon icon={['fas','eye']} />
+                  )}
+                  <FontAwesomeIcon
+                    icon={['fas',`${nodeData.properties.renderingLayer ? 'eye' : 'eye-slash'}`]}
+                  />
+                </>
+              );
+            }}
+          />
+          <RulesDrawer />
+        </ReactGeoMapContext.Provider>
+      </div>
+    </>
+  );
+};

--- a/frontend/src/Components/WmsTable/WmsTable.tsx
+++ b/frontend/src/Components/WmsTable/WmsTable.tsx
@@ -1,5 +1,7 @@
-import { Button } from 'antd';
+import { UnlockOutlined } from '@ant-design/icons';
+import { Button, Space } from 'antd';
 import React, { useRef } from 'react';
+import { useNavigate } from 'react-router';
 import WmsRepo from '../../Repos/WmsRepo';
 import RepoTable, { RepoActionType, RepoTableColumnType } from '../Shared/Table/RepoTable';
 import { buildSearchTransformDateRange } from '../Shared/Table/TableHelper';
@@ -9,6 +11,7 @@ const repo = new WmsRepo();
 
 const WmsTable = (): JSX.Element => {
   const actionRef = useRef<RepoActionType>();
+  const navigate = useNavigate();
   const columns: RepoTableColumnType[] = [{
     dataIndex: 'id',
     title: 'ID'
@@ -126,6 +129,7 @@ const WmsTable = (): JSX.Element => {
     render: (text: any, record:any) => {
       return (
         <>
+          <Space size='middle'>
             <Button
               danger
               size='small'
@@ -135,6 +139,16 @@ const WmsTable = (): JSX.Element => {
             >
               Löschen
             </Button>
+            <Button
+              size='small'
+              icon={<UnlockOutlined/>}
+              onClick={ () => {
+                navigate(`/registry/services/wms/${record.id}/security`);
+              }}
+            >
+              Zugriff einschränken
+            </Button>
+          </Space>
         </>
       );
     }

--- a/frontend/src/Repos/WmsRepo.ts
+++ b/frontend/src/Repos/WmsRepo.ts
@@ -11,7 +11,7 @@ class WebMapServiceRepo extends JsonApiRepo {
   constructor () {
     super('/api/v1/registry/wms/', 'Darstellungsdienste (WMS)');
   }
-  
+
   async create (create: OgcServiceCreate): Promise<JsonApiResponse> {
     const attributes = {
       get_capabilities_url: create.get_capabilities_url, // eslint-disable-line
@@ -27,6 +27,24 @@ class WebMapServiceRepo extends JsonApiRepo {
     };
     return this.add('WebMapService', attributes, relationships);
   }
+
+  async getAllLayers (id: string): Promise<JsonApiResponse> {
+    const client = await JsonApiRepo.getClientInstance();
+    const params = [
+      {
+        in: 'path',
+        name: 'parent_lookup_service',
+        value: id,
+      },
+      {
+        in: 'query',
+        name: 'page[size]',
+        value: 1000,
+      }
+    ];
+    return await client['List' + this.resourcePath + '{parent_lookup_service}/layers/'](params);
+  }
+
 }
 
 export default WebMapServiceRepo;

--- a/frontend/src/Utils/TreeUtils.ts
+++ b/frontend/src/Utils/TreeUtils.ts
@@ -35,7 +35,7 @@ export class TreeUtils {
     * @param list
     * @returns
     */
-  private MPTTListToTreeNodeList(list:MPTTJsonApiTreeNodeType[]):TreeNodeType[] {
+  private mapContextLayersToTreeNodeList(list:MPTTJsonApiTreeNodeType[]):TreeNodeType[] {
     const roots:TreeNodeType[] = [];
   
     // initialize children on the list element
@@ -79,7 +79,42 @@ export class TreeUtils {
     });
     return roots;
   }
-  
+
+  private wmsLayersToTreeNodeList(list:any[]):TreeNodeType[] {
+    const roots:TreeNodeType[] = [];
+
+    // initialize children on the list element
+    list = list.map((element: any) => ({ ...element, children: [] }));
+
+    list.map((element) => {
+      const node: TreeNodeType = {
+        key: element.id,
+        title: element.attributes.title,
+        parent: element.relationships.parent.data?.id,
+        children: element.children || [],
+        isLeaf: element.children && element.children.length === 0,
+        properties: {
+          title: element.attributes.title, // yes, title is repeated
+          scaleMin: element.attributes.scale_min,
+          scaleMax: element.attributes.scale_max,
+        },
+        expanded: true
+      };
+
+      if (node.parent) {
+        const parentNode: MPTTJsonApiTreeNodeType | undefined = list.find((el:any) => el.id === node.parent);
+        if (parentNode) {
+          list[list.indexOf(parentNode)].children?.push(node);
+        }
+      } else {
+        roots.push(node);
+      }
+      return element;
+    });
+
+    return roots;
+  }
+
   private TreeNodeListToOlLayerGroup(list: TreeNodeType[]): Collection<LayerGroup | ImageLayer<ImageWMS>> {
     const layerList = list.map((node: TreeNodeType) => {
       if (node.children.length > 0) {
@@ -123,9 +158,18 @@ export class TreeUtils {
     return new Collection(layerList);
   }
   
-  public MPTTListToOLLayerGroup(list:MPTTJsonApiTreeNodeType[]): Collection<LayerGroup | BaseLayer> {
+  public mapContextLayersToOlLayerGroup(list:MPTTJsonApiTreeNodeType[]): Collection<LayerGroup | BaseLayer> {
     if(list) {
-      const treeNodeList = this.MPTTListToTreeNodeList(list);
+      const treeNodeList = this.mapContextLayersToTreeNodeList(list);
+      const layerGroupList = this.TreeNodeListToOlLayerGroup(treeNodeList);
+      return layerGroupList;
+    }
+    return new Collection();
+  }
+
+  public wmsLayersToOlLayerGroup(list:MPTTJsonApiTreeNodeType[]): Collection<LayerGroup | BaseLayer> {
+    if(list) {
+      const treeNodeList = this.wmsLayersToTreeNodeList(list);
       const layerGroupList = this.TreeNodeListToOlLayerGroup(treeNodeList);
       return layerGroupList;
     }


### PR DESCRIPTION
This PR implements #390 and #392.

![Peek 2022-01-27 16-02](https://user-images.githubusercontent.com/289590/151386971-18cb2129-d36a-4a73-8106-fc90a0ae5c39.gif)


Changes:

- Added `WmsSecuritySettings` component
- Added `WmsSecuritySettings/RulesDrawer` component
- Added route`/registry/services/wms/:id/security`
- Moved `OgcService/WmsTable` component to `WmsTable`
- Added button for security settings to `WmsTable`
- Added method `getAllLayers` to `WmsRepo` (for retrieving all Layers of a WMS instance)
- Extended `TreeUtils` with `wmsLayersToOlLayerGroup` method
- Renamed `TreeUtils#MPTTListToOLLayerGroup` to `TreeUtils#mapContextLayersToOlLayerGroup` (to clarify it's purpose)