### PR TITLE
WMS Security Proxy Settings: Rule List and basic rule form operation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,7 +111,7 @@ export default function App (): JSX.Element {
             element={<RegisterServiceForm repo={new WebMapServiceRepo()} />}
           />
           <Route
-            path='/registry/services/wms/:id/security'
+            path='/registry/services/wms/:id/security/*'
             element={<WmsSecuritySettings />}
           />
           <Route

--- a/frontend/src/Components/MapContextForm/MapContextForm.tsx
+++ b/frontend/src/Components/MapContextForm/MapContextForm.tsx
@@ -121,7 +121,7 @@ export const MapContextForm = (): ReactElement => {
         //@ts-ignore
         const layerOpts: CreateLayerOpts = {
           url: '',
-          version: '1.1.0',
+          version: '1.1.1',
           format: 'image/png',
           layers: '',
           serverType: 'MAPSERVER',

--- a/frontend/src/Components/Shared/RepoTable/RepoTable.tsx
+++ b/frontend/src/Components/Shared/RepoTable/RepoTable.tsx
@@ -110,7 +110,7 @@ const RepoTable = ({
 
   // augment / build columns from schema (and add delete action)
   useEffect(() => {
-
+    let isMounted = true;
     async function buildColumns () {
       const resourceSchema = await repo.getResourceSchema();
       const queryParams = await repo.getQueryParams();
@@ -145,9 +145,10 @@ const RepoTable = ({
           }
         });
       }
-      setAugmentedColumns(_augmentedColumns);
+      isMounted && setAugmentedColumns(_augmentedColumns);
     }
     buildColumns();
+    return () => { isMounted = false; }; // componentWillUnmount handler
   }, [columns, onEditRecord, repo]);
 
   // fetches data in format expected by antd ProTable component

--- a/frontend/src/Components/Shared/TreeManager/TreeManager.tsx
+++ b/frontend/src/Components/Shared/TreeManager/TreeManager.tsx
@@ -6,7 +6,7 @@ import { EventDataNode } from 'antd/lib/tree';
 import React, { cloneElement, createRef, useEffect, useState } from 'react';
 import { TreeUtils } from '../../../Utils/TreeUtils';
 import './TreeManager.css';
-import { DropNodeEventType, TreeNodeType, TreeProps } from './TreeManagerTypes';
+import { DropNodeEventType, TreeManagerProps, TreeNodeType } from './TreeManagerTypes';
 
 const treeUtils = new TreeUtils();
 
@@ -33,7 +33,8 @@ export const TreeManager = ({
   extendedNodeActions= () => undefined,
   treeNodeTitlePreIcons = () => (<></>),
   multipleSelection = false,
-}: TreeProps): JSX.Element => {
+  selectedKeys = undefined
+}: TreeManagerProps): JSX.Element => {
   const [form] = useForm();
 
   const nodeNameTextInput:any = createRef();
@@ -645,6 +646,14 @@ export const TreeManager = ({
     }
   }, [nodeNameTextInput, isEditingNodeName]);
 
+  // workaround for omitting the selectedKeys attribute completely from the Tree element
+  // not sure why, but providing undefined as value of the attribute does not switch of the controlled keys behaviour
+  // of the component, while omitting it completely does...
+  const selectedKeysAttr = {} as any;
+  if (selectedKeys !== undefined) {
+    selectedKeysAttr.selectedKeys = selectedKeys;
+  }
+
   return (
     <div className='tree-form-field' >
       <div 
@@ -665,6 +674,7 @@ export const TreeManager = ({
         </Tooltip>
       </div>
       <Tree
+        {...selectedKeysAttr}
         checkedKeys={checkedKeys}
         checkable={checkableNodes}
         className='tree-form-field-tree'

--- a/frontend/src/Components/Shared/TreeManager/TreeManagerTypes.ts
+++ b/frontend/src/Components/Shared/TreeManager/TreeManagerTypes.ts
@@ -57,7 +57,7 @@ export interface TreeNodeType extends DataNode {
     expanded?: boolean;
   }
   
-export interface TreeProps {
+export interface TreeManagerProps {
     treeData: TreeNodeType[];
     asyncTree?: boolean;
     addNodeDispatchAction?:(
@@ -85,4 +85,6 @@ export interface TreeProps {
     customTreeTitleAction?: () => void | undefined;
     treeNodeTitlePreIcons?: (nodeData:TreeNodeType) => ReactNode;
     multipleSelection?: boolean;
+    /** (Controlled) Specifies the keys of the selected treeNodes, cf. https://ant.design/components/tree/#API */
+    selectedKeys?: string[];
   }

--- a/frontend/src/Components/TheMap/LayerManager/LayerManager.tsx
+++ b/frontend/src/Components/TheMap/LayerManager/LayerManager.tsx
@@ -49,7 +49,8 @@ export const LayerManager = ({
   layerAttributeInfoIcons = () => (<></>),
   layerAttributeForm,
   initLayerTreeData,
-  multipleSelection = false
+  multipleSelection = false,
+  selectedLayerIds = undefined
 }: LayerManagerProps): JSX.Element => {
   // TODO: all logic to handle layers or interaction between map and layers should be handled here,
   // not to the tree form field component.
@@ -391,6 +392,8 @@ export const LayerManager = ({
           nodeAttributeForm={layerAttributeForm}
           treeNodeTitlePreIcons={layerAttributeInfoIcons}
           multipleSelection={multipleSelection}
+          selectedKeys={selectedLayerIds}
+
         />
       )}
     </div>

--- a/frontend/src/Components/TheMap/LayerManager/LayerManagerTypes.ts
+++ b/frontend/src/Components/TheMap/LayerManager/LayerManagerTypes.ts
@@ -7,11 +7,11 @@ type OlWMSServerType = 'ESRI' | 'GEOSERVER' | 'MAPSERVER' | 'QGIS';
 
 export interface CreateLayerOpts {
   url: string;
-  version: '1.1.0' | '1.1.1' | '1.3.0';
+  version: '1.1.1' | '1.3.0';
   format: 'image/jpeg' | 'image/png';
   layers: string;
   visible: boolean;
-  serverType: OlWMSServerType;
+  serverType?: OlWMSServerType;
   layerId?: string | number;
   legendUrl: string;
   title: string;

--- a/frontend/src/Components/TheMap/LayerManager/LayerManagerTypes.ts
+++ b/frontend/src/Components/TheMap/LayerManager/LayerManagerTypes.ts
@@ -38,4 +38,6 @@ export interface LayerManagerProps {
   layerAttributeInfoIcons?: (nodeData: TreeNodeType) => ReactNode;
   layerAttributeForm?: ReactNode;
   multipleSelection?: boolean;
+  /** (Controlled) Specifies the keys of the selected layers */
+  selectedLayerIds?: string[];
 }

--- a/frontend/src/Components/TheMap/TheMap.tsx
+++ b/frontend/src/Components/TheMap/TheMap.tsx
@@ -77,7 +77,8 @@ export const TheMap = ({
   layerAttributeForm,
   layerAttributeInfoIcons = () => (<></>),
   allowMultipleLayerSelection = false,
-  showLayerManager = false
+  showLayerManager = false,
+  selectedLayerIds = undefined
 }: {
   addLayerDispatchAction?:(
     nodeAttributes: any,
@@ -97,6 +98,7 @@ export const TheMap = ({
   layerAttributeInfoIcons?: (nodeData: TreeNodeType) => ReactNode;
   allowMultipleLayerSelection?: boolean;
   showLayerManager?: boolean;
+  selectedLayerIds?: string[];
 }): JSX.Element => {
   const map = useMap();
 
@@ -181,6 +183,7 @@ export const TheMap = ({
           layerEditErrorDispatchAction={layerEditErrorDispatchAction}
           layerAttributeInfoIcons={layerAttributeInfoIcons}
           multipleSelection={allowMultipleLayerSelection}
+          selectedLayerIds={selectedLayerIds}
         />
       )}
       <MapComponent

--- a/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
@@ -1,5 +1,5 @@
-import { Button, Form, notification, Space } from 'antd';
-import { default as React, ReactElement } from 'react';
+import { Alert, Button, Form, notification, Space } from 'antd';
+import { default as React, ReactElement, useState } from 'react';
 import { useNavigate } from 'react-router';
 import WmsAllowedOperationRepo, { WmsAllowedOperationCreate } from '../../../Repos/WmsAllowedOperationRepo';
 import { InputField } from '../../Shared/FormFields/InputField/InputField';
@@ -18,7 +18,15 @@ export const RuleForm = ({
 
   const navigate = useNavigate();
 
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
   const onFinish = (values: any) => {
+
+    if (selectedLayerIds.length === 0) {
+      setValidationErrors(['At least one layer needs to be selected.']);
+      return;
+    }
+
     const create: WmsAllowedOperationCreate = {
       description: values.description,
       securedLayerIds: selectedLayerIds,
@@ -54,6 +62,16 @@ export const RuleForm = ({
             hasFeedback: true
           }}          
         />
+        {
+          validationErrors.map((error, i) => (
+            <Form.Item key={i}>
+              <Alert
+                description={error}
+                type='error'
+              />
+            </Form.Item>
+          ))
+        }
         <Form.Item>
           <Space>
             <Button

--- a/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
@@ -1,28 +1,29 @@
-import { Button, Form, Input, notification } from 'antd';
+import { Button, Form, notification, Space } from 'antd';
 import { default as React, ReactElement } from 'react';
 import { useNavigate } from 'react-router';
 import WmsAllowedOperationRepo, { WmsAllowedOperationCreate } from '../../../Repos/WmsAllowedOperationRepo';
+import { InputField } from '../../Shared/FormFields/InputField/InputField';
 
 interface RuleFormProps {
-    wmsId: string
+    wmsId: string,
+    selectedLayerIds: string[]
 }
 
 export const RuleForm = ({
-  wmsId
+  wmsId,
+  selectedLayerIds
 }: RuleFormProps): ReactElement => {
-
-  const navigate = useNavigate();
-  //   const [groups, setGroups] = useState([]);
 
   const ruleRepo = new WmsAllowedOperationRepo(wmsId);
 
-  const onFinish = (values: any) => {
+  const navigate = useNavigate();
 
+  const onFinish = (values: any) => {
     const create: WmsAllowedOperationCreate = {
       title: values.title,
-      securedLayerIds: ['2da5a138-7c80-4841-8e80-a4462685e3e1'],
-      allowedOperationIds: ['GetMap', 'GetFeatureInfo'],
-      allowedGroupIds: ['1']
+      securedLayerIds: selectedLayerIds,
+      allowedOperationIds: ['GetMap'], // TODO
+      allowedGroupIds: [] // TODO
     };
 
     async function postData () {
@@ -44,29 +45,32 @@ export const RuleForm = ({
         layout='vertical'
         onFinish={onFinish}
       >
-        <Form.Item
-          name='title'
-          label='Titel'
-          required={true}
-        >
-          <Input />
-        </Form.Item>
+        <InputField
+          label='Description'
+          name='description'
+          placeholder='Short description of the security rule'
+          validation={{
+            rules: [{ required: true, message: 'Please input a description!' }],
+            hasFeedback: true
+          }}          
+        />
         <Form.Item>
-          <Button
-            type='primary'
-            htmlType='submit'
-          >
-            Speichern
-          </Button>
-          <Button
-            htmlType='button'
-            onClick={ () => navigate(`/registry/services/wms/${wmsId}/security`)}
-          >
-            Abbrechen
-          </Button>
-        </Form.Item>                
+          <Space>
+            <Button
+              type='primary'
+              htmlType='submit'
+            >
+              Speichern
+            </Button>
+            <Button
+              htmlType='button'
+              onClick={ () => navigate(`/registry/services/wms/${wmsId}/security`)}
+            >
+              Abbrechen
+            </Button>
+          </Space>
+        </Form.Item>
       </Form>
     </>
   );
 };
-

--- a/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
@@ -20,7 +20,7 @@ export const RuleForm = ({
 
   const onFinish = (values: any) => {
     const create: WmsAllowedOperationCreate = {
-      title: values.title,
+      description: values.description,
       securedLayerIds: selectedLayerIds,
       allowedOperationIds: ['GetMap'], // TODO
       allowedGroupIds: [] // TODO

--- a/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
@@ -1,6 +1,7 @@
-import { Button, Form, Input } from 'antd';
+import { Button, Form, Input, notification } from 'antd';
 import { default as React, ReactElement } from 'react';
 import { useNavigate } from 'react-router';
+import WmsAllowedOperationRepo, { WmsAllowedOperationCreate } from '../../../Repos/WmsAllowedOperationRepo';
 
 interface RuleFormProps {
     wmsId: string
@@ -13,10 +14,35 @@ export const RuleForm = ({
   const navigate = useNavigate();
   //   const [groups, setGroups] = useState([]);
 
+  const ruleRepo = new WmsAllowedOperationRepo(wmsId);
+
+  const onFinish = (values: any) => {
+
+    const create: WmsAllowedOperationCreate = {
+      title: values.title,
+      securedLayerIds: ['2da5a138-7c80-4841-8e80-a4462685e3e1'],
+      allowedOperationIds: ['GetMap', 'GetFeatureInfo'],
+      allowedGroupIds: ['1']
+    };
+
+    async function postData () {
+      const res = await ruleRepo.create(create);
+      if (res.status === 201) {
+        notification.info({
+          message: 'WMS security rule created',
+          description: 'Your WMS security rule has been created'
+        });
+        navigate(`/registry/services/wms/${wmsId}/security`);
+      }
+    }
+    postData();
+  };
+
   return (
     <>
       <Form         
         layout='vertical'
+        onFinish={onFinish}
       >
         <Form.Item
           name='title'

--- a/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RuleForm/RuleForm.tsx
@@ -1,0 +1,46 @@
+import { Button, Form, Input } from 'antd';
+import { default as React, ReactElement } from 'react';
+import { useNavigate } from 'react-router';
+
+interface RuleFormProps {
+    wmsId: string
+}
+
+export const RuleForm = ({
+  wmsId
+}: RuleFormProps): ReactElement => {
+
+  const navigate = useNavigate();
+  //   const [groups, setGroups] = useState([]);
+
+  return (
+    <>
+      <Form         
+        layout='vertical'
+      >
+        <Form.Item
+          name='title'
+          label='Titel'
+          required={true}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item>
+          <Button
+            type='primary'
+            htmlType='submit'
+          >
+            Speichern
+          </Button>
+          <Button
+            htmlType='button'
+            onClick={ () => navigate(`/registry/services/wms/${wmsId}/security`)}
+          >
+            Abbrechen
+          </Button>
+        </Form.Item>                
+      </Form>
+    </>
+  );
+};
+

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesDrawer.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesDrawer.tsx
@@ -1,6 +1,8 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, Drawer } from 'antd';
 import React, { ReactElement, useRef, useState } from 'react';
+import { Route, Routes } from 'react-router-dom';
+import { RuleForm } from '../RuleForm/RuleForm';
 import './RulesDrawer.css';
 import { RulesTable } from './RulesTable/RulesTable';
 
@@ -37,7 +39,18 @@ export const RulesDrawer = ({
         closable={false}
         mask={false}
       >
-        <RulesTable wmsId={wmsId} />
+        <Routes>           
+          <Route
+            path='/'
+            element={<RulesTable 
+              wmsId={wmsId}
+            />}
+          />
+          <Route
+            path='rules/add'
+            element={<RuleForm wmsId={wmsId}/>}
+          />
+        </Routes>
       </Drawer>
     </>
   );

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesDrawer.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesDrawer.tsx
@@ -7,11 +7,15 @@ import './RulesDrawer.css';
 import { RulesTable } from './RulesTable/RulesTable';
 
 export interface RulesDrawerProps {
-  wmsId: string
+  wmsId: string,
+  selectedLayerIds: string[],
+  setSelectedLayerIds: (ids: string[]) => void
 }
 
 export const RulesDrawer = ({
-  wmsId
+  wmsId,
+  selectedLayerIds,
+  setSelectedLayerIds
 }: RulesDrawerProps): ReactElement => {
 
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -42,13 +46,21 @@ export const RulesDrawer = ({
         <Routes>           
           <Route
             path='/'
-            element={<RulesTable 
-              wmsId={wmsId}
-            />}
+            element={(
+              <RulesTable 
+                wmsId={wmsId}
+                setSelectedLayerIds={setSelectedLayerIds}
+              />
+            )}
           />
           <Route
             path='rules/add'
-            element={<RuleForm wmsId={wmsId}/>}
+            element={(
+              <RuleForm 
+                wmsId={wmsId}
+                selectedLayerIds={selectedLayerIds}
+              />
+            )}
           />
         </Routes>
       </Drawer>

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesDrawer.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesDrawer.tsx
@@ -62,6 +62,15 @@ export const RulesDrawer = ({
               />
             )}
           />
+          <Route
+            path='rules/:ruleId/edit'
+            element={(
+              <RuleForm 
+                wmsId={wmsId}
+                selectedLayerIds={selectedLayerIds}
+              />
+            )}
+          />          
         </Routes>
       </Drawer>
     </>

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesDrawer.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesDrawer.tsx
@@ -2,8 +2,16 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, Drawer } from 'antd';
 import React, { ReactElement, useRef, useState } from 'react';
 import './RulesDrawer.css';
+import { RulesTable } from './RulesTable/RulesTable';
 
-export const RulesDrawer = (): ReactElement => {
+export interface RulesDrawerProps {
+  wmsId: string
+}
+
+export const RulesDrawer = ({
+  wmsId
+}: RulesDrawerProps): ReactElement => {
+
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [isVisible, setIsVisible] = useState<boolean>(true);
   const toggleVisible = () => {
@@ -29,7 +37,7 @@ export const RulesDrawer = (): ReactElement => {
         closable={false}
         mask={false}
       >
-          Rules
+        <RulesTable wmsId={wmsId} />
       </Drawer>
     </>
   );

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesTable/RulesTable.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesTable/RulesTable.tsx
@@ -1,0 +1,24 @@
+import React, { ReactElement } from 'react';
+import { useNavigate } from 'react-router-dom';
+import WmsAllowedOperationRepo from '../../../../Repos/WmsAllowedOperationRepo';
+import RepoTable from '../../../Shared/RepoTable/RepoTable';
+
+export interface RulesTableProps {
+  wmsId: string
+}
+
+export const RulesTable = ({
+  wmsId
+}:RulesTableProps): ReactElement => {
+  const navigate = useNavigate();
+  // no side effects, so useEffect is not needed here
+  const repo = new WmsAllowedOperationRepo(wmsId);
+
+  return (
+    <RepoTable
+      repo={repo}
+      onAddRecord={`/registry/services/wms/${wmsId}/security/rules/add`}
+      onEditRecord={(recordId) => navigate(`/registry/services/wms/${wmsId}/security/rules/${recordId}/edit`)}
+    />
+  );
+};

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesTable/RulesTable.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesTable/RulesTable.tsx
@@ -4,21 +4,25 @@ import WmsAllowedOperationRepo from '../../../../Repos/WmsAllowedOperationRepo';
 import RepoTable from '../../../Shared/RepoTable/RepoTable';
 
 export interface RulesTableProps {
-  wmsId: string
+  wmsId: string,
+  setSelectedLayerIds: (ids: string[]) => void
 }
 
 export const RulesTable = ({
-  wmsId
-}:RulesTableProps): ReactElement => {
+  wmsId,
+  setSelectedLayerIds
+}: RulesTableProps): ReactElement => {
   const navigate = useNavigate();
   // no side effects, so useEffect is not needed here
   const repo = new WmsAllowedOperationRepo(wmsId);
 
   return (
-    <RepoTable
-      repo={repo}
-      onAddRecord={`/registry/services/wms/${wmsId}/security/rules/add`}
-      onEditRecord={(recordId) => navigate(`/registry/services/wms/${wmsId}/security/rules/${recordId}/edit`)}
-    />
+    <>
+      <RepoTable
+        repo={repo}
+        onAddRecord={`/registry/services/wms/${wmsId}/security/rules/add`}
+        onEditRecord={(recordId) => navigate(`/registry/services/wms/${wmsId}/security/rules/${recordId}/edit`)}
+      />
+    </>
   );
 };

--- a/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesTable/RulesTable.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/RulesDrawer/RulesTable/RulesTable.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
 import WmsAllowedOperationRepo from '../../../../Repos/WmsAllowedOperationRepo';
-import RepoTable from '../../../Shared/RepoTable/RepoTable';
+import RepoTable, { RepoTableColumnType } from '../../../Shared/RepoTable/RepoTable';
 
 export interface RulesTableProps {
   wmsId: string,
@@ -16,10 +16,31 @@ export const RulesTable = ({
   // no side effects, so useEffect is not needed here
   const repo = new WmsAllowedOperationRepo(wmsId);
 
+  const columns: RepoTableColumnType[] = [{
+    dataIndex: 'description',
+    title: 'Beschreibung',
+    sorter: false
+  },{
+    dataIndex: 'id',
+    hideInTable: true
+  },{
+    dataIndex: 'is_accessible',
+    hideInTable: true
+  },{
+    dataIndex: 'allowed_area',
+    hideInTable: true
+  }];
+
   return (
     <>
       <RepoTable
         repo={repo}
+        columns={columns}
+        options={{
+          setting: false,
+          density: false
+        }}
+        pagination={false}
         onAddRecord={`/registry/services/wms/${wmsId}/security/rules/add`}
         onEditRecord={(recordId) => navigate(`/registry/services/wms/${wmsId}/security/rules/${recordId}/edit`)}
       />

--- a/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.tsx
@@ -1,18 +1,113 @@
 import { SyncOutlined } from '@ant-design/icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MapContext as ReactGeoMapContext } from '@terrestris/react-geo';
 import Collection from 'ol/Collection';
+import BaseLayer from 'ol/layer/Base';
+import LayerGroup from 'ol/layer/Group';
+import ImageLayer from 'ol/layer/Image';
+import ImageWMS from 'ol/source/ImageWMS';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import WmsRepo from '../../Repos/WmsRepo';
-import { TreeUtils } from '../../Utils/TreeUtils';
-import { TreeNodeType } from '../Shared/TreeManager/TreeManagerTypes';
+import { LayerUtils } from '../../Utils/LayerUtils';
+import { MPTTJsonApiTreeNodeType, TreeNodeType } from '../Shared/TreeManager/TreeManagerTypes';
+import { CreateLayerOpts } from '../TheMap/LayerManager/LayerManagerTypes';
 import { olMap, TheMap } from '../TheMap/TheMap';
 import { RulesDrawer } from './RulesDrawer/RulesDrawer';
 import './WmsSecuritySettings.css';
 
 const wmsRepo = new WmsRepo();
-const treeUtils = new TreeUtils();
+const layerUtils = new LayerUtils();
+
+function wmsLayersToTreeNodeList(list:any[]):TreeNodeType[] {
+  const roots:TreeNodeType[] = [];
+
+  // initialize children on the list element
+  list = list.map((element: any) => ({ ...element, children: [] }));
+
+  list.map((element) => {
+    const node: TreeNodeType = {
+      key: element.id,
+      title: element.attributes.title,
+      parent: element.relationships.parent.data?.id,
+      children: element.children || [],
+      isLeaf: element.children && element.children.length === 0,
+      properties: {
+        origId: element.attributes.identifier,
+        title: element.attributes.title, // yes, title is repeated
+        scaleMin: element.attributes.scale_min,
+        scaleMax: element.attributes.scale_max,
+      },
+      expanded: true
+    };
+
+    if (node.parent) {
+      const parentNode: MPTTJsonApiTreeNodeType | undefined = list.find((el:any) => el.id === node.parent);
+      if (parentNode) {
+        list[list.indexOf(parentNode)].children?.push(node);
+      }
+    } else {
+      roots.push(node);
+    }
+    return element;
+  });
+
+  return roots;
+}
+
+function TreeNodeListToOlLayerGroup(list: TreeNodeType[], 
+  getMapUrl:string, wmsVersion:string): Collection<LayerGroup | ImageLayer<ImageWMS>> {
+  const layerList = list.map((node: TreeNodeType) => {
+
+    if (node.children.length > 0) {
+      const layerGroupOpts = {
+        opacity: 1,
+        visible: false,
+        properties: {
+          title: node.properties.title,
+          description: node.properties.description,
+          parent: node.parent,
+          key: node.key,
+          layerId: node.key
+        },
+        layers: TreeNodeListToOlLayerGroup(node.children, getMapUrl, wmsVersion)
+      };
+      return new LayerGroup(layerGroupOpts);
+    } 
+
+    if(node.children.length === 0) {
+      const layerOpts: CreateLayerOpts = {
+        url: getMapUrl,
+        version: wmsVersion as any,
+        format: 'image/png',
+        layers: node.properties.origId,
+        serverType: 'MAPSERVER',
+        visible: false,
+        legendUrl: '',
+        title: node.properties.title,
+        description: node.properties.description,
+        layerId: node.key,
+        properties: {
+          ...node.properties,
+          parent: node.parent,
+          key: node.key,
+        }
+      };
+      return layerUtils.createMrMapOlWMSLayer(layerOpts);
+    }
+    return new LayerGroup();
+  });
+  return new Collection(layerList);
+}
+
+function wmsLayersToOlLayerGroup(list:MPTTJsonApiTreeNodeType[], 
+  getMapUrl:string, wmsVersion:string): Collection<LayerGroup | BaseLayer> {
+  if(list) {
+    const treeNodeList = wmsLayersToTreeNodeList(list);
+    const layerGroupList = TreeNodeListToOlLayerGroup(treeNodeList, getMapUrl, wmsVersion);
+    return layerGroupList;
+  }
+  return new Collection();
+}
 
 export const WmsSecuritySettings = (): ReactElement => {
 
@@ -24,16 +119,23 @@ export const WmsSecuritySettings = (): ReactElement => {
   const [initLayerTreeData, setInitLayerTreeData] = useState<Collection<any>>(new Collection());  
 
   useEffect(() => {
-    // TODO: need to add some sort of loading until the values are fetched
-    // olMap.addLayer(mapContextLayersPreviewGroup);
     if (id) {
       setIsLoading(true);
-      const fetchWmsLayers = async () => {
+      const fetchWmsAndLayers = async () => {
         try {
-          // const response = await mapContextRepo.getMapContextWithLayers(String(id));
+          const jsonApiWmsWithOpUrls = await wmsRepo.get(String(id)) as any;
+          const getMapUrl = jsonApiWmsWithOpUrls.data.included.filter((opUrl:any) => {
+            return opUrl.attributes.method === 'Get' && opUrl.attributes.operation === 'GetMap';
+          }).map ((opUrl:any) => {
+            return opUrl.attributes.url;
+          }).reduce ( 
+            (acc:string, curr:string) => curr, null
+          );
+          const wmsAttrs = jsonApiWmsWithOpUrls.data.data.attributes;
+          const wmsVersion = wmsAttrs.version;
           const response = await wmsRepo.getAllLayers(String(id));
-          // Convert the mapContext layers coming from the server to a compatible tree node list
-          const _initLayerTreeData = treeUtils.wmsLayersToOlLayerGroup((response as any).data?.data);
+          // convert the WMS layers coming from the server to a compatible tree node list
+          const _initLayerTreeData = wmsLayersToOlLayerGroup((response as any).data?.data, getMapUrl, wmsVersion);
           setInitLayerTreeData(_initLayerTreeData);
         } catch (error) {
           // @ts-ignore
@@ -42,11 +144,10 @@ export const WmsSecuritySettings = (): ReactElement => {
           setIsLoading(false);
         }
       };      
-      fetchWmsLayers();
+      fetchWmsAndLayers();
     }
   }, [id]);
 
-  // TODO: replace for a decent loading screen
   if(isLoading) {
     return (<SyncOutlined spin />);
   }
@@ -64,21 +165,6 @@ export const WmsSecuritySettings = (): ReactElement => {
             layerGroupName='mrMapWmsSecurityLayers'
             initLayerTreeData={initLayerTreeData}
             layerAttributeForm={(<h1>Placeholder</h1>)}
-            layerAttributeInfoIcons={(nodeData:TreeNodeType) => {
-              if(!nodeData.isLeaf) {
-                return (<></>);
-              }
-              return (
-                <>
-                  {nodeData.properties.datasetMetadata && (
-                    <FontAwesomeIcon icon={['fas','eye']} />
-                  )}
-                  <FontAwesomeIcon
-                    icon={['fas',`${nodeData.properties.renderingLayer ? 'eye' : 'eye-slash'}`]}
-                  />
-                </>
-              );
-            }}
             selectedLayerIds={selectedLayerIds}
           />
           { 

--- a/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.tsx
@@ -20,14 +20,15 @@ export const WmsSecuritySettings = (): ReactElement => {
   const { id } = useParams();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [initLayerTreeData, setInitLayerTreeData] = useState<Collection<any>>(new Collection());
+  const [selectedLayerIds, setSelectedLayerIds] = useState<string[]>([]);
+  const [initLayerTreeData, setInitLayerTreeData] = useState<Collection<any>>(new Collection());  
 
   useEffect(() => {
     // TODO: need to add some sort of loading until the values are fetched
     // olMap.addLayer(mapContextLayersPreviewGroup);
     if (id) {
       setIsLoading(true);
-      const fetchMapContext = async () => {
+      const fetchWmsLayers = async () => {
         try {
           // const response = await mapContextRepo.getMapContextWithLayers(String(id));
           const response = await wmsRepo.getAllLayers(String(id));
@@ -40,8 +41,8 @@ export const WmsSecuritySettings = (): ReactElement => {
         } finally {
           setIsLoading(false);
         }
-      };
-      fetchMapContext();
+      };      
+      fetchWmsLayers();
     }
   }, [id]);
 
@@ -56,7 +57,10 @@ export const WmsSecuritySettings = (): ReactElement => {
         <ReactGeoMapContext.Provider value={olMap}>
           <TheMap
             showLayerManager
-            selectLayerDispatchAction={(selectedKeys, info) => console.log('selected', info.node)}
+            allowMultipleLayerSelection
+            selectLayerDispatchAction={(selectedKeys, info) => { 
+              setSelectedLayerIds(selectedKeys as string[]);
+            }}
             layerGroupName='mrMapWmsSecurityLayers'
             initLayerTreeData={initLayerTreeData}
             layerAttributeForm={(<h1>Placeholder</h1>)}
@@ -75,8 +79,16 @@ export const WmsSecuritySettings = (): ReactElement => {
                 </>
               );
             }}
+            selectedLayerIds={selectedLayerIds}
           />
-          { id && <RulesDrawer wmsId={id}/> }
+          { 
+            id && 
+            <RulesDrawer 
+              wmsId={id}
+              selectedLayerIds={selectedLayerIds}
+              setSelectedLayerIds={ (ids:string[]) => { setSelectedLayerIds(ids); } }
+            /> 
+          }
         </ReactGeoMapContext.Provider>
       </div>
     </>

--- a/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.tsx
+++ b/frontend/src/Components/WmsSecuritySettings/WmsSecuritySettings.tsx
@@ -76,7 +76,7 @@ export const WmsSecuritySettings = (): ReactElement => {
               );
             }}
           />
-          <RulesDrawer />
+          { id && <RulesDrawer wmsId={id}/> }
         </ReactGeoMapContext.Provider>
       </div>
     </>

--- a/frontend/src/Repos/LayerRepo.ts
+++ b/frontend/src/Repos/LayerRepo.ts
@@ -83,7 +83,7 @@ class LayerRepo extends JsonApiRepo {
         params: { include: 'service.operation_urls' }
       }
     );
-    
+
     let styles;
     let included;
     let extent = null;

--- a/frontend/src/Repos/WmsAllowedOperationRepo.ts
+++ b/frontend/src/Repos/WmsAllowedOperationRepo.ts
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie';
 import JsonApiRepo, { JsonApiMimeType, JsonApiResponse, QueryParams } from './JsonApiRepo';
 
 export interface WmsAllowedOperationCreate {
-  title: string;
+  description: string;
   allowedGroupIds: Array<string>;
   allowedOperationIds: Array<string>;
   securedLayerIds: Array<string>;
@@ -13,7 +13,7 @@ class WmsAllowedOperationRepo extends JsonApiRepo {
   readonly wmsId: string;
 
   constructor (wmsId: string) {
-    super('/api/v1/registry/wms/{parent_lookup_secured_service}/allowed-wms-operations/', 'Regeln');
+    super('/api/v1/registry/wms/{parent_lookup_secured_service}/allowed-wms-operations/', 'Zugriffsregeln');
     this.wmsId = wmsId;
   }
 
@@ -74,7 +74,7 @@ class WmsAllowedOperationRepo extends JsonApiRepo {
 
   async create (create: WmsAllowedOperationCreate): Promise<JsonApiResponse> {
     const attributes = {
-      description: create.title
+      description: create.description
     };
     const relationships = {
       'secured_service': {

--- a/frontend/src/Repos/WmsAllowedOperationRepo.ts
+++ b/frontend/src/Repos/WmsAllowedOperationRepo.ts
@@ -1,0 +1,31 @@
+import JsonApiRepo, { JsonApiResponse, QueryParams } from './JsonApiRepo';
+
+
+class WmsAllowedOperationRepo extends JsonApiRepo {
+
+  readonly wmsId: string;
+
+  constructor (wmsId: string) {
+    super('/api/v1/registry/wms/{parent_lookup_secured_service}/allowed-wms-operations/', 'Regeln');
+    this.wmsId = wmsId;
+  }
+
+  async findAll (queryParams?: QueryParams): Promise<JsonApiResponse> {
+    const client = await JsonApiRepo.getClientInstance();
+    let jsonApiParams: any;
+    if (queryParams) {
+      jsonApiParams = {
+        'page[number]': queryParams.page,
+        'page[size]': queryParams.pageSize,
+        ...queryParams.filters
+      };
+      if (queryParams.ordering) {
+        jsonApiParams.sort = queryParams.ordering;
+      }
+    }
+    return await client['List' + this.resourcePath](this.wmsId, jsonApiParams);
+  }
+
+}
+
+export default WmsAllowedOperationRepo;

--- a/frontend/src/Repos/WmsAllowedOperationRepo.ts
+++ b/frontend/src/Repos/WmsAllowedOperationRepo.ts
@@ -1,5 +1,12 @@
-import JsonApiRepo, { JsonApiResponse, QueryParams } from './JsonApiRepo';
+import Cookies from 'js-cookie';
+import JsonApiRepo, { JsonApiMimeType, JsonApiResponse, QueryParams } from './JsonApiRepo';
 
+export interface WmsAllowedOperationCreate {
+  title: string;
+  allowedGroupIds: Array<string>;
+  allowedOperationIds: Array<string>;
+  securedLayerIds: Array<string>;
+}
 
 class WmsAllowedOperationRepo extends JsonApiRepo {
 
@@ -24,6 +31,84 @@ class WmsAllowedOperationRepo extends JsonApiRepo {
       }
     }
     return await client['List' + this.resourcePath](this.wmsId, jsonApiParams);
+  }
+
+  async add (type: string, attributes: any, relationships?: any): Promise<JsonApiResponse> {
+    const client = await JsonApiRepo.getClientInstance();
+    return await client['create' + this.resourcePath](this.wmsId, {
+      data: {
+        type: type,
+        attributes: {
+          ...attributes
+        },
+        relationships: {
+          ...relationships
+        }
+      }
+    }, {
+      headers: { 'Content-Type': JsonApiMimeType, 'X-CSRFToken': Cookies.get('csrftoken') },
+    });
+  }
+
+  async delete (id: string): Promise<JsonApiResponse> {
+    const client = await JsonApiRepo.getClientInstance();
+    const params = [
+      {
+        in: 'path',
+        name: 'parent_lookup_secured_service',
+        value: this.wmsId,
+      },
+      {
+        in: 'path',
+        name: 'id',
+        value: id,
+      },      
+      {
+        in: 'header',
+        name: 'X-CSRFToken',
+        value: Cookies.get('csrftoken') || ''
+      }
+    ];    
+    return await client['destroy' + this.resourcePath + '{id}/'](params);
+  }
+
+  async create (create: WmsAllowedOperationCreate): Promise<JsonApiResponse> {
+    const attributes = {
+      description: create.title
+    };
+    const relationships = {
+      'secured_service': {
+        data: {
+          type: 'WebMapService',
+          id: this.wmsId
+        }
+      },
+      'secured_layers': {
+        data: create.securedLayerIds.map((id) => {
+          return {
+            type: 'Layer',
+            id: id
+          };
+        })
+      },
+      'operations': {
+        data: create.allowedOperationIds.map((id) => {
+          return {
+            type: 'WebMapServiceOperation',
+            id: id
+          };
+        })
+      },
+      'allowed_groups': {
+        data: create.allowedGroupIds.map((id) => {
+          return {
+            type: 'Group',
+            id: id
+          };
+        })
+      }      
+    };
+    return this.add('AllowedWebMapServiceOperation', attributes, relationships);
   }
 
 }

--- a/frontend/src/Repos/WmsRepo.ts
+++ b/frontend/src/Repos/WmsRepo.ts
@@ -28,6 +28,28 @@ class WebMapServiceRepo extends JsonApiRepo {
     return this.add('WebMapService', attributes, relationships);
   }
 
+  async get (id: string): Promise<JsonApiResponse> {
+    const client = await JsonApiRepo.getClientInstance();
+    const params = [
+      {
+        in: 'path',
+        name: 'id',
+        value: id,
+      },
+      {
+        in: 'header',
+        name: 'Content-Type',
+        value: 'JsonApiMimeType',
+      },
+      {
+        in: 'query',
+        name: 'include',
+        value: 'operation_urls'
+      }
+    ];    
+    return await client['retrieve' + this.resourcePath + '{id}/'](params);
+  }
+
   async getAllLayers (id: string): Promise<JsonApiResponse> {
     const client = await JsonApiRepo.getClientInstance();
     const params = [

--- a/frontend/src/Utils/TreeUtils.ts
+++ b/frontend/src/Utils/TreeUtils.ts
@@ -85,41 +85,6 @@ export class TreeUtils {
     return roots;
   }
 
-  private wmsLayersToTreeNodeList(list:any[]):TreeNodeType[] {
-    const roots:TreeNodeType[] = [];
-
-    // initialize children on the list element
-    list = list.map((element: any) => ({ ...element, children: [] }));
-
-    list.map((element) => {
-      const node: TreeNodeType = {
-        key: element.id,
-        title: element.attributes.title,
-        parent: element.relationships.parent.data?.id,
-        children: element.children || [],
-        isLeaf: element.children && element.children.length === 0,
-        properties: {
-          title: element.attributes.title, // yes, title is repeated
-          scaleMin: element.attributes.scale_min,
-          scaleMax: element.attributes.scale_max,
-        },
-        expanded: true
-      };
-
-      if (node.parent) {
-        const parentNode: MPTTJsonApiTreeNodeType | undefined = list.find((el:any) => el.id === node.parent);
-        if (parentNode) {
-          list[list.indexOf(parentNode)].children?.push(node);
-        }
-      } else {
-        roots.push(node);
-      }
-      return element;
-    });
-
-    return roots;
-  }
-
   private TreeNodeListToOlLayerGroup(list: TreeNodeType[]): Collection<LayerGroup | ImageLayer<ImageWMS>> {
     const layerList = list.map((node: TreeNodeType) => {
       if (node.children.length > 0) {
@@ -141,12 +106,11 @@ export class TreeUtils {
       if(node.children.length === 0) {
         const layerOpts: CreateLayerOpts = {
           url: '',
-          version: '1.1.0',
+          layers: 'dummy value, set later',
+          legendUrl: 'dummy value, set later',
+          version: '1.1.1',
           format: 'image/png',
-          layers: '',
-          serverType: 'MAPSERVER',
           visible: false,
-          legendUrl: '',
           title: node.properties.title,
           description: node.properties.description,
           layerId: node.key,
@@ -162,19 +126,10 @@ export class TreeUtils {
     });
     return new Collection(layerList);
   }
-  
+
   public mapContextLayersToOlLayerGroup(list:MPTTJsonApiTreeNodeType[]): Collection<LayerGroup | BaseLayer> {
     if(list) {
       const treeNodeList = this.mapContextLayersToTreeNodeList(list);
-      const layerGroupList = this.TreeNodeListToOlLayerGroup(treeNodeList);
-      return layerGroupList;
-    }
-    return new Collection();
-  }
-
-  public wmsLayersToOlLayerGroup(list:MPTTJsonApiTreeNodeType[]): Collection<LayerGroup | BaseLayer> {
-    if(list) {
-      const treeNodeList = this.wmsLayersToTreeNodeList(list);
       const layerGroupList = this.TreeNodeListToOlLayerGroup(treeNodeList);
       return layerGroupList;
     }


### PR DESCRIPTION
This implements #393 and #394.

Changes:

* `RepoTable`: Fix 'React state update on unmounted component' error.
* `WmsSecuritySettings`: Added RulesTable.
* `RuleForm`: Implemented Cancel button.
* `RuleForm`: Implemented creating of new rules.
* `RuleForm`: Extended TreeManager, LayerManager, TheMap components with properties for setting selected layer ids / node ids.
* `RulesForm`: Use selected layers from LayerManager.
* `RulesTable`: Lipstick on table presentation
* `RuleForm`: Added validation for a selected layer.
* `CreateLayerOpts`: Removed non-existing WMS version 1.1.1, made server type optional.
* `TreeUtils`: Moved WmsSecuritySettings-specific code from TreeUtils to WmsSecuritySettings. To be unified later.
* `RulesDrawer`: Added route for editing rules.
