### PR TITLE
bugfix/reverse-proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,7 +227,7 @@ services:
       - mrmap-internal    
   flower:
     image: mher/flower:2.0
-    command: ["celery", "--broker=redis://redis:6379", "flower", "--port=5555"]
+    command: ["celery", "--broker=redis://redis:6379", "flower", "--port=5555", "--url_prefix=flower"]
     networks:
       - mrmap-internal
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,9 @@ services:
         - VITE_API_PORT=${EXTERNAL_PORT:?Please configure EXTERNAL_PORT in the .env file}
         - VITE_API_SCHEMA=${EXTERNAL_SCHEME:?Please configure EXTERNAL_SCHEME in the .env file}
     hostname: "nginx"
+    environment:
+      - no_proxy=${no_proxy:-localhost},backend,flower,pgadmin
+      - NO_PROXY=${NO_PROXY:-localhost},backend,flower,pgadmin
     volumes:
       - type: bind
         source: ./docker/nginx/mrmap.conf

--- a/docker/nginx/mrmap.conf
+++ b/docker/nginx/mrmap.conf
@@ -58,7 +58,7 @@ server{
         resolver 127.0.0.11 valid=30;
         set $upstream_flower flower;
 
-        proxy_pass http://$upstream_flower/flower;
+        proxy_pass http://$upstream_flower:5555;
         proxy_redirect off;
 
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
flower needs to be made aware that it is reachable under a subpath and the nginx configuration for flower was missing the correct port

second commit adds internal hostnames to the no_proxy variable of the frontend service, so reverse proxying also works in environments where an outbound proxy is configured