### PR TITLE
replace use of the pytz library with the zoneinfo module

### DIFF
--- a/backend/extras/serializers.py
+++ b/backend/extras/serializers.py
@@ -1,6 +1,6 @@
 import datetime
+import zoneinfo
 
-import pytz
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import resolve
@@ -109,7 +109,7 @@ class TimeUntilNextRunMixin:
         now_local = timezone.localtime(timezone.now())
 
         # Zeitzone aus Crontab (oder fallback UTC)
-        tz = obj.crontab.timezone or pytz.UTC
+        tz = obj.crontab.timezone or zoneinfo.ZoneInfo("UTC")
 
         # Jetzt in Crontab-Zeitzone konvertieren
         now_tz = now_local.astimezone(tz)
@@ -131,5 +131,4 @@ class TimeUntilNextRunMixin:
             parts.append(f"{minutes}min")
         parts.append(f"{seconds}s")
 
-        return " ".join(parts)
         return " ".join(parts)

--- a/backend/system/fields.py
+++ b/backend/system/fields.py
@@ -1,59 +1,59 @@
+import datetime
 import re
+import zoneinfo
 
-import pytz
 from django.conf import settings
 from django_celery_beat.models import CrontabSchedule
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 CRONTAB_TIME_REGEX = (
-    r"^(?P<minute>[\d\*/,\-]+)\s+"
+    r"(?P<minute>[\d\*/,\-]+)\s+"
     r"(?P<hour>[\d\*/,\-]+)\s+"
     r"(?P<day_of_month>[\d\*/,\-]+)\s+"
     r"(?P<month_of_year>[\d\*/,\-]+)\s+"
     r"(?P<day_of_week>[\d\*/,\-]+)"
-    r"(?:\s+(?P<timezone>UTC(?:[+-]\d{1,2}(?::\d{2})?)?))?"
-    r"\Z"
+    r"(?:\s+(?P<timezone>\S+))?"
 )
 
 
-def parse_utc_timezone(tz_string: str) -> pytz.BaseTzInfo:
-    """Konvertiert UTC+X oder UTC-X:XX in eine pytz-Zeitzone."""
-    if tz_string == "UTC":
-        return pytz.UTC
-    match = re.fullmatch(r"UTC([+-])(\d{1,2})(?::(\d{2}))?", tz_string)
+def parse_timezone(tz_string: str) -> datetime.tzinfo:
+    """Konvertiert einen Timezone-String in ein ZoneInfo-Objekt."""
+    try:
+        return zoneinfo.ZoneInfo(tz_string)
+    except zoneinfo.ZoneInfoNotFoundError:
+        pass
+
+    match = re.fullmatch(r"UTC([+-]\d{1,2})", tz_string)
     if not match:
         raise ValueError(f"Unsupported timezone format: {tz_string}")
-    sign, hours, minutes = match.groups()
-    offset_hours = int(hours)
-    offset_minutes = int(minutes or 0)
-    total_offset = offset_hours + offset_minutes / 60
-    if sign == "+":
-        gmt_offset = -total_offset
-    else:
-        gmt_offset = total_offset
-    # pytz uses reversed signs: UTC+2 → Etc/GMT-2
-    gmt_name = f"Etc/GMT{int(gmt_offset):+d}"
-    return pytz.timezone(gmt_name)
+    utc_offset = int(match.group(1))
+    # Etc/GMT* zones use reversed signs (POSIX style)
+    gmt_offset = -utc_offset
+    gmt_name = f"Etc/GMT{gmt_offset:+d}"
+    return zoneinfo.ZoneInfo(gmt_name)
 
 
-class CrontabStringField(serializers.CharField):
+@extend_schema_field(str)
+class CrontabStringField(serializers.Field):
     def __init__(self, **kwargs):
-        super().__init__(
-            help_text="Crontab-Zeitstring mit optionaler UTC-Zeitzone (z. B. '0 12 * * 1-5 UTC+2')",
-            **kwargs
+        help_text = kwargs.pop(
+            "help_text",
+            "Crontab-Zeitstring mit optionaler Zeitzone (z. B. '0 12 * * 1-5 UTC+2')",
         )
+        super().__init__(help_text=help_text, **kwargs)
 
-    def to_representation(self, obj: CrontabSchedule):
-        base = f"{obj.minute} {obj.hour} {obj.day_of_month} {obj.month_of_year} {obj.day_of_week}"
-        if obj.timezone:
-            base += f" {obj.timezone.key}"
+    def to_representation(self, value: CrontabSchedule) -> str:
+        base = f"{value.minute} {value.hour} {value.day_of_month} {value.month_of_year} {value.day_of_week}"
+        if value.timezone:
+            base += f" {value.timezone.key}"
         return base
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: str) -> CrontabSchedule:
         data = data.strip()
         match = re.fullmatch(CRONTAB_TIME_REGEX, data)
         if not match:
-            raise serializers.ValidationError("Invalid crontab string format.")
+            raise serializers.ValidationError(f"Invalid crontab string format: {data}")
         values = match.groupdict()
         minute = values["minute"]
         hour = values["hour"]
@@ -65,11 +65,11 @@ class CrontabStringField(serializers.CharField):
         # Zeitzone bestimmen
         if tz_string:
             try:
-                timezone = parse_utc_timezone(tz_string)
+                timezone = parse_timezone(tz_string)
             except Exception as e:
                 raise serializers.ValidationError(str(e))
         else:
-            timezone = pytz.timezone(settings.TIME_ZONE)
+            timezone = zoneinfo.ZoneInfo(settings.TIME_ZONE)
 
         obj, _ = CrontabSchedule.objects.get_or_create(
             minute=minute,


### PR DESCRIPTION
The Django Project dropped pytz in favor of the zoneinfo module from the standard library with Django 4.0, so let's do the same (pytz is imported in only 2 modules anyway).

This commit also rewrites the timezone parsing logic of the CrontabStringField serializer field in system/fields.py. In addition to UTC offsets, we now allow everything in the system's timezone database (or the tzdata package, if the former is not available) as a timezone string. The code handling sub-hour UTC offsets is removed because neither pytz nor tzdata support these.